### PR TITLE
chore(.gitignore): add bin to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -73,3 +73,4 @@ deps
 
 tests/tmp
 
+bin


### PR DESCRIPTION
在执行完`build.sh`后，项目目录下会产生bin文件夹，里面有日志信息和可执行文件，应当添加到.gitignore中不被git追踪