### PR TITLE
feat:Subcommands support separate command id

### DIFF
--- a/src/base_cmd.cc
+++ b/src/base_cmd.cc
@@ -48,7 +48,7 @@ bool BaseCmd::HasFlag(uint32_t flag) const { return flag_ & flag; }
 void BaseCmd::SetFlag(uint32_t flag) { flag_ |= flag; }
 void BaseCmd::ResetFlag(uint32_t flag) { flag_ &= ~flag; }
 bool BaseCmd::HasSubCommand() const { return false; }
-BaseCmd* BaseCmd::GetSubCmd(const std::string& cmdNane) { return nullptr; }
+BaseCmd* BaseCmd::GetSubCmd(const std::string& cmdName) { return nullptr; }
 uint32_t BaseCmd::AclCategory() const { return aclCategory_; }
 void BaseCmd::AddAclCategory(uint32_t aclCategory) { aclCategory_ |= aclCategory; }
 std::string BaseCmd::Name() const { return name_; }
@@ -63,8 +63,8 @@ BaseCmdGroup::BaseCmdGroup(const std::string& name, int16_t arity, uint32_t flag
 
 void BaseCmdGroup::AddSubCmd(std::unique_ptr<BaseCmd> cmd) { subCmds_[cmd->Name()] = std::move(cmd); }
 
-BaseCmd* BaseCmdGroup::GetSubCmd(const std::string& cmdNane) {
-  auto subCmd = subCmds_.find(cmdNane);
+BaseCmd* BaseCmdGroup::GetSubCmd(const std::string& cmdName) {
+  auto subCmd = subCmds_.find(cmdName);
   if (subCmd == subCmds_.end()) {
     return nullptr;
   }

--- a/src/base_cmd.h
+++ b/src/base_cmd.h
@@ -5,10 +5,10 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
-#ifndef PIKIWIDB_SRC_BASE_CMD_H
-#define PIKIWIDB_SRC_BASE_CMD_H
+#pragma once
 
 #include <atomic>
+#include <map>
 #include <memory>
 #include <span>
 #include <string>
@@ -159,9 +159,8 @@ class BaseCmd : public std::enable_shared_from_this<BaseCmd> {
   // then these functions do not need to be implemented.
   // If it is a subcommand, you need to implement these functions
   // e.g: CmdConfig is a subcommand, and the subcommand is set and get
-  virtual bool HasSubCommand() const;                      // The command is there a sub command
-  virtual std::vector<std::string> SubCommand() const;     // Get command is there a sub command
-  virtual int8_t SubCmdIndex(const std::string& cmdName);  // if the command no subCommand，return -1；
+  virtual bool HasSubCommand() const;  // The command is there a sub command
+  virtual BaseCmd* GetSubCmd(const std::string& cmdNane);
 
   uint32_t AclCategory() const;
   void AddAclCategory(uint32_t aclCategory);
@@ -186,7 +185,6 @@ class BaseCmd : public std::enable_shared_from_this<BaseCmd> {
   std::string name_;
   int16_t arity_ = 0;
   uint32_t flag_ = 0;
-  std::vector<std::string> subCmdName_;  // sub command name, may be empty
 
   //  CmdRes res_;
   //  std::string dbName_;
@@ -207,5 +205,22 @@ class BaseCmd : public std::enable_shared_from_this<BaseCmd> {
   //  BaseCmd& operator=(const BaseCmd&);
 };
 
+class BaseCmdGroup : public BaseCmd {
+ public:
+  BaseCmdGroup(const std::string& name, uint32_t flag);
+  BaseCmdGroup(const std::string& name, int16_t arity, uint32_t flag);
+
+  ~BaseCmdGroup() override = default;
+
+  void AddSubCmd(std::unique_ptr<BaseCmd> cmd);
+  BaseCmd* GetSubCmd(const std::string& cmdNane) override;
+
+  void DoCmd(CmdContext& ctx) override{};
+
+  bool DoInitial(CmdContext& ctx) override;
+
+ private:
+  std::map<std::string, std::unique_ptr<BaseCmd>> subCmds_;
+};
+
 }  // namespace pikiwidb
-#endif  // PIKIWIDB_SRC_BASE_CMD_H

--- a/src/base_cmd.h
+++ b/src/base_cmd.h
@@ -160,7 +160,7 @@ class BaseCmd : public std::enable_shared_from_this<BaseCmd> {
   // If it is a subcommand, you need to implement these functions
   // e.g: CmdConfig is a subcommand, and the subcommand is set and get
   virtual bool HasSubCommand() const;  // The command is there a sub command
-  virtual BaseCmd* GetSubCmd(const std::string& cmdNane);
+  virtual BaseCmd* GetSubCmd(const std::string& cmdName);
 
   uint32_t AclCategory() const;
   void AddAclCategory(uint32_t aclCategory);
@@ -213,10 +213,12 @@ class BaseCmdGroup : public BaseCmd {
   ~BaseCmdGroup() override = default;
 
   void AddSubCmd(std::unique_ptr<BaseCmd> cmd);
-  BaseCmd* GetSubCmd(const std::string& cmdNane) override;
+  BaseCmd* GetSubCmd(const std::string& cmdName) override;
 
+  // group cmd this function will not be called
   void DoCmd(CmdContext& ctx) override{};
 
+  // group cmd this function will not be called
   bool DoInitial(CmdContext& ctx) override;
 
  private:

--- a/src/client.cc
+++ b/src/client.cc
@@ -260,13 +260,13 @@ int PClient::handlePacketNew(const std::vector<std::string>& params, const std::
     return 0;
   }
 
-  if (cmdPtr->CheckArg(params.size())) {
+  if (!cmdPtr->CheckArg(params.size())) {
     ctx.SetRes(CmdRes::kSyntaxErr, "wrong number of arguments for '" + cmd + "' command");
     reply_.PushData(ctx.message().data(), ctx.message().size());
     return 0;
   }
 
-  //execute a specific command
+  // execute a specific command
   cmdPtr->Execute(ctx);
 
   reply_.PushData(ctx.message().data(), ctx.message().size());

--- a/src/client.cc
+++ b/src/client.cc
@@ -248,10 +248,10 @@ int PClient::handlePacketNew(const std::vector<std::string>& params, const std::
   std::vector<std::string> argv = params;
   ctx.argv_ = argv;
 
-  auto cmdPtr = g_pikiwidb->GetCmdTableManager().GetCommand(cmd, ctx);
+  auto [cmdPtr, ret] = g_pikiwidb->GetCmdTableManager().GetCommand(cmd, ctx);
 
-  if (!cmdPtr.first) {
-    if (cmdPtr.second == CmdRes::kInvalidParameter) {
+  if (!cmdPtr) {
+    if (ret == CmdRes::kInvalidParameter) {
       ctx.SetRes(CmdRes::kInvalidParameter);
     } else {
       ctx.SetRes(CmdRes::kSyntaxErr, "unknown command '" + cmd + "'");
@@ -260,13 +260,14 @@ int PClient::handlePacketNew(const std::vector<std::string>& params, const std::
     return 0;
   }
 
-  if (cmdPtr.first->CheckArg(params.size())) {
+  if (cmdPtr->CheckArg(params.size())) {
     ctx.SetRes(CmdRes::kSyntaxErr, "wrong number of arguments for '" + cmd + "' command");
     reply_.PushData(ctx.message().data(), ctx.message().size());
     return 0;
   }
 
-  cmdPtr.first->Execute(ctx);
+  //execute a specific command
+  cmdPtr->Execute(ctx);
 
   reply_.PushData(ctx.message().data(), ctx.message().size());
   return 0;

--- a/src/client.h
+++ b/src/client.h
@@ -102,7 +102,7 @@ class PClient : public std::enable_shared_from_this<PClient> {
  private:
   std::shared_ptr<TcpConnection> getTcpConnection() const { return tcp_connection_.lock(); }
   int handlePacket(pikiwidb::TcpConnection*, const char*, int);
-  int handlePacketNew(pikiwidb::TcpConnection* obj, const std::vector<std::string>& params, const std::string& cmd);
+  int handlePacketNew(const std::vector<std::string>& params, const std::string& cmd);
   int processInlineCmd(const char*, size_t, std::vector<PString>&);
   void reset();
   bool isPeerMaster() const;

--- a/src/cmd_admin.cc
+++ b/src/cmd_admin.cc
@@ -9,48 +9,24 @@
 
 namespace pikiwidb {
 
-CmdConfig::CmdConfig(const std::string& name, int arity) : BaseCmd(name, arity, CmdFlagsAdmin, AclCategoryAdmin) {
+CmdConfig::CmdConfig(const std::string& name, int arity) : BaseCmdGroup(name, CmdFlagsAdmin, AclCategoryAdmin) {
   subCmd_ = {"set", "get"};
 }
 
 bool CmdConfig::HasSubCommand() const { return true; }
 
-std::vector<std::string> CmdConfig::SubCommand() const { return subCmd_; }
+CmdConfigGet::CmdConfigGet(const std::string& name, int16_t arity)
+    : BaseCmd(name, arity, CmdFlagsAdmin | CmdFlagsWrite, AclCategoryAdmin) {}
 
-int8_t CmdConfig::SubCmdIndex(const std::string& cmdName) {
-  for (size_t i = 0; i < subCmd_.size(); i++) {
-    if (subCmd_[i] == cmdName) {
-      return i;
-    }
-  }
-  return -1;
-}
+bool CmdConfigGet::DoInitial(CmdContext& ctx) { return true; }
 
-bool CmdConfig::DoInitial(pikiwidb::CmdContext& ctx) {
-  ctx.subCmd_ = ctx.argv_[1];
-  std::transform(ctx.argv_[1].begin(), ctx.argv_[1].end(), ctx.subCmd_.begin(), ::tolower);
-  if (ctx.subCmd_ == subCmd_[0] || ctx.subCmd_ == subCmd_[1]) {
-    if (ctx.argv_.size() < 3) {
-      ctx.SetRes(CmdRes::kInvalidParameter, "config " + ctx.subCmd_);
-      return false;
-    }
-  }
+void CmdConfigGet::DoCmd(CmdContext& ctx) { ctx.AppendString("config cmd in development"); }
 
-  return true;
-}
+CmdConfigSet::CmdConfigSet(const std::string& name, int16_t arity)
+    : BaseCmd(name, arity, CmdFlagsAdmin, AclCategoryAdmin) {}
 
-void CmdConfig::DoCmd(pikiwidb::CmdContext& ctx) {
-  if (ctx.subCmd_ == subCmd_[0]) {
-    Set(ctx);
-  } else if (ctx.subCmd_ == subCmd_[1]) {
-    Get(ctx);
-  } else {
-    ctx.SetRes(CmdRes::kSyntaxErr, "config error");
-  }
-}
+bool CmdConfigSet::DoInitial(CmdContext& ctx) { return true; }
 
-void CmdConfig::Get(CmdContext& ctx) { ctx.AppendString("config cmd in development"); }
-
-void CmdConfig::Set(CmdContext& ctx) { ctx.AppendString("config cmd in development"); }
+void CmdConfigSet::DoCmd(CmdContext& ctx) { ctx.AppendString("config cmd in development"); }
 
 }  // namespace pikiwidb

--- a/src/cmd_admin.h
+++ b/src/cmd_admin.h
@@ -12,24 +12,41 @@
 
 namespace pikiwidb {
 
-class CmdConfig : public BaseCmd {
+class CmdConfig : public BaseCmdGroup {
  public:
   CmdConfig(const std::string& name, int arity);
 
   bool HasSubCommand() const override;
-  std::vector<std::string> SubCommand() const override;
-  int8_t SubCmdIndex(const std::string& cmdName) override;
+
+ protected:
+  bool DoInitial(CmdContext& ctx) override { return true; };
+
+ private:
+  std::vector<std::string> subCmd_;
+
+  void DoCmd(CmdContext& ctx) override{};
+};
+
+class CmdConfigGet : public BaseCmd {
+ public:
+  CmdConfigGet(const std::string& name, int16_t arity);
 
  protected:
   bool DoInitial(CmdContext& ctx) override;
 
  private:
-  std::vector<std::string> subCmd_;
+  void DoCmd(pikiwidb::CmdContext& ctx) override;
+};
 
-  void DoCmd(CmdContext& ctx) override;
+class CmdConfigSet : public BaseCmd {
+ public:
+  CmdConfigSet(const std::string& name, int16_t arity);
 
-  void Get(CmdContext& ctx);
-  void Set(CmdContext& ctx);
+ protected:
+  bool DoInitial(CmdContext& ctx) override;
+
+ private:
+  void DoCmd(pikiwidb::CmdContext& ctx) override;
 };
 
 }  // namespace pikiwidb

--- a/src/cmd_kv.cc
+++ b/src/cmd_kv.cc
@@ -10,7 +10,7 @@
 
 namespace pikiwidb {
 
-GetCmd::GetCmd(const std::string& name, int arity)
+GetCmd::GetCmd(const std::string& name, int16_t arity)
     : BaseCmd(name, arity, CmdFlagsReadonly, AclCategoryRead | AclCategoryString) {}
 
 bool GetCmd::DoInitial(CmdContext& ctx) {
@@ -34,7 +34,7 @@ void GetCmd::DoCmd(CmdContext& ctx) {
   ctx.AppendString(reply);
 }
 
-SetCmd::SetCmd(const std::string& name, int arity)
+SetCmd::SetCmd(const std::string& name, int16_t arity)
     : BaseCmd(name, arity, CmdFlagsWrite, AclCategoryWrite | AclCategoryString) {}
 
 bool SetCmd::DoInitial(CmdContext& ctx) {

--- a/src/cmd_kv.h
+++ b/src/cmd_kv.h
@@ -14,7 +14,7 @@ namespace pikiwidb {
 
 class GetCmd : public BaseCmd {
  public:
-  GetCmd(const std::string &name, int arity);
+  GetCmd(const std::string &name, int16_t arity);
 
  protected:
   bool DoInitial(CmdContext &ctx) override;
@@ -25,7 +25,7 @@ class GetCmd : public BaseCmd {
 
 class SetCmd : public BaseCmd {
  public:
-  SetCmd(const std::string &name, int arity);
+  SetCmd(const std::string &name, int16_t arity);
 
  protected:
   bool DoInitial(CmdContext &ctx) override;

--- a/src/cmd_table_manager.h
+++ b/src/cmd_table_manager.h
@@ -28,7 +28,7 @@ class CmdTableManager {
 
  public:
   void InitCmdTable();
-  BaseCmd* GetCommand(const std::string& cmdName);
+  std::pair<BaseCmd*,CmdRes::CmdRet> GetCommand(const std::string& cmdName, CmdContext& ctx);
   //  uint32_t DistributeKey(const std::string& key, uint32_t slot_num);
   bool CmdExist(const std::string& cmd) const;
   uint32_t GetCmdId();


### PR DESCRIPTION
每个拥有子命令的命令 (比如 config get, config set) 这样的命令, 以前的时候是一个 `config` 命令, 通过 第二个参数来区分具体执行哪个, `config set`, `config get` 这些命令id是同一个.

这样会带来一个问题, `config set`在ACL中属于写命令, `config get` 在ACL中属于 读命令, 如果使用 之前那种所有子命令id相同的时, 无法为子命令区分 不同的ACL类型

现在改成了 每个子命令(和redis 处理方式一样) 有单独的id, 可以为不同的子命令 区分不同的 ACL类型, 方便 权限划分

`std::pair<BaseCmd*, CmdRes::CmdRet> CmdTableManager::GetCommand(const std::string& cmdName, CmdContext& ctx) `
这里的返回值使用了 `std::pair`, 来同时返回两个值, 不知出否妥当, 如有更好的解决方法,还请指正