### PR TITLE
fix: fix the return context when the number of parameters is wrong

### DIFF
--- a/src/client.cc
+++ b/src/client.cc
@@ -388,7 +388,7 @@ void PClient::executeCommand() {
   }
 
   if (!cmdPtr->CheckArg(params_.size())) {
-    SetRes(CmdRes::kSyntaxErr, "wrong number of arguments for '" + CmdName() + "' command");
+    SetRes(CmdRes::kWrongNum, CmdName());
     return;
   }
 


### PR DESCRIPTION
输入命令参数与设定不符合时，会返回“-ERR syntax error”，与redis不一致
- 修复前
![4e05daae49ca32cc6552cd9ec8f1dff](https://github.com/OpenAtomFoundation/pikiwidb/assets/77976092/49bc855b-fd45-4caf-9835-1b24027d0a3c)
- 修复后
![image](https://github.com/OpenAtomFoundation/pikiwidb/assets/77976092/3fa2bfca-2202-4e40-a1c6-9da320baa7e1)
