### PR TITLE
feat: implement the decrby command

### DIFF
--- a/src/base_cmd.h
+++ b/src/base_cmd.h
@@ -34,6 +34,7 @@ const std::string kCmdNameGetSet = "getset";
 const std::string kCmdNameSetNX = "setnx";
 const std::string kCmdNameAppend = "append";
 const std::string kCmdNameIncrby = "incrby";
+const std::string kCmdNameDecrby = "decrby";
 const std::string kCmdNameIncrbyFloat = "incrbyfloat";
 const std::string kCmdNameStrlen = "strlen";
 const std::string kCmdNameSetEx = "setex";

--- a/src/cmd_kv.cc
+++ b/src/cmd_kv.cc
@@ -436,6 +436,43 @@ void IncrbyCmd::DoCmd(PClient* client) {
   }
 }
 
+DecrbyCmd::DecrbyCmd(const std::string& name, int16_t arity)
+    : BaseCmd(name, arity, kCmdFlagsWrite, kAclCategoryWrite | kAclCategoryString) {}
+
+bool DecrbyCmd::DoInitial(PClient* client) {
+  int64_t by = 0;
+  if (!(pstd::String2int(client->argv_[2].data(), client->argv_[2].size(), &by))) {
+    client->SetRes(CmdRes::kInvalidInt);
+    return false;
+  }
+  client->SetKey(client->argv_[1]);
+  return true;
+}
+
+void DecrbyCmd::DoCmd(PClient* client) {
+  int64_t new_value = 0;
+  int64_t by = 0;
+  pstd::String2int(client->argv_[2].data(), client->argv_[2].size(), &by);
+  PError err = PSTORE.Decrby(client->Key(), by, &new_value);
+  switch (err) {
+    case kPErrorType:
+      client->SetRes(CmdRes::kInvalidInt);
+      break;
+    case kPErrorNotExist:  // key not exist, set a new value
+      by *= -1;
+      PSTORE.ClearExpire(client->Key());  // clear key's old ttl
+      PSTORE.SetValue(client->Key(), PObject::CreateString(by));
+      client->AppendInteger(by);
+      break;
+    case kPErrorOK:
+      client->AppendInteger(new_value);
+      break;
+    default:
+      client->SetRes(CmdRes::kErrOther, "decrby cmd error");
+      break;
+  }
+}
+
 IncrbyFloatCmd::IncrbyFloatCmd(const std::string& name, int16_t arity)
     : BaseCmd(name, arity, kCmdFlagsWrite, kAclCategoryWrite | kAclCategoryString) {}
 

--- a/src/cmd_kv.h
+++ b/src/cmd_kv.h
@@ -159,6 +159,16 @@ class IncrbyCmd : public BaseCmd {
  private:
   void DoCmd(PClient *client) override;
 };
+class DecrbyCmd : public BaseCmd {
+ public:
+  DecrbyCmd(const std::string &name, int16_t arity);
+
+ protected:
+  bool DoInitial(PClient *client) override;
+
+ private:
+  void DoCmd(PClient *client) override;
+};
 
 class GetBitCmd : public BaseCmd {
  public:

--- a/src/cmd_table_manager.cc
+++ b/src/cmd_table_manager.cc
@@ -51,6 +51,7 @@ void CmdTableManager::InitCmdTable() {
   ADD_COMMAND(Append, 3);
   ADD_COMMAND(Strlen, 2);
   ADD_COMMAND(Incrby, 3);
+  ADD_COMMAND(Decrby, 3);
   ADD_COMMAND(IncrbyFloat, 3);
   ADD_COMMAND(SetEx, 4);
   ADD_COMMAND(PSetEx, 4);

--- a/src/store.h
+++ b/src/store.h
@@ -121,6 +121,7 @@ class PStore {
   PObject* SetValue(const PString& key, PObject&& value);
   // incr
   PError Incrby(const PString& key, int64_t value, int64_t* ret);
+  PError Decrby(const PString& key, int64_t value, int64_t* ret);
   PError Incrbyfloat(const PString& key, std::string value, std::string* ret);
 
   // for expire key


### PR DESCRIPTION
Implement `decrby` in the pikiwii string command, and the result is as follows:
<img width="237" alt="CleanShot 2023-12-17 at 16 02 14@2x" src="https://github.com/OpenAtomFoundation/pikiwidb/assets/51713304/7f13b635-9833-40c6-8fe5-2bd6da0c559d">
