### PR TITLE
fix: number string conversion exception

### DIFF
--- a/src/common.cc
+++ b/src/common.cc
@@ -45,8 +45,9 @@ struct PErrorInfo g_errorInfo[] = {
     {sizeof "-ERR module already loaded\r\n" - 1, "-ERR module already loaded\r\n"},
 };
 
-bool IsValidNumber(const std::string& str, std::size_t slen) {
-  if (slen == 0) {
+bool IsValidNumber(const std::string& str) {
+  size_t slen = str.size();
+  if (slen == 0 || slen > 20) {
     return false;
   }
 

--- a/src/common.cc
+++ b/src/common.cc
@@ -45,9 +45,9 @@ struct PErrorInfo g_errorInfo[] = {
     {sizeof "-ERR module already loaded\r\n" - 1, "-ERR module already loaded\r\n"},
 };
 
-bool IsValidNumber(const std::string& str) {
+bool IsValidNumber(const PString& str) {
   size_t slen = str.size();
-  if (slen == 0 || slen > 20) {
+  if (slen == 0 || slen >= 20 || (str[0] != '-' && !isdigit(str[0]))) {
     return false;
   }
 
@@ -69,6 +69,12 @@ bool IsValidNumber(const std::string& str) {
       return false;
     }
   }
+
+  // TODO:
+  // @jettcc
+  // If this method is used to determine whether a numeric string is valid,
+  // it should consider whether the string exceeds the range of int64,
+  // that is, the string should be a valid long long number.
 
   return true;
 }
@@ -176,20 +182,14 @@ bool Strtol(const char* ptr, size_t nBytes, long* outVal) {
   }
 
   errno = 0;
-
-  size_t pEnd = 0;
-  std::string str(ptr, nBytes);
-  try {
-    *outVal = std::stol(str, &pEnd, 10);
-  } catch (...) {
-    return false;
-  }
+  char* pEnd = 0;
+  *outVal = strtol(ptr, &pEnd, 0);
 
   if (errno == ERANGE || errno == EINVAL) {
     return false;
   }
 
-  return pEnd == nBytes;
+  return pEnd == ptr + nBytes;
 }
 
 bool Strtoll(const char* ptr, size_t nBytes, long long* outVal) {

--- a/src/common.h
+++ b/src/common.h
@@ -145,6 +145,8 @@ inline std::size_t Number2Str(char* ptr, std::size_t nBytes, T val) {
   return off;
 }
 
+bool IsValidNumber(const std::string& str, std::size_t slen);
+
 int Double2Str(char* ptr, std::size_t nBytes, double val);
 int StrToLongDouble(const char* s, size_t slen, long double* ldval);
 int LongDoubleToStr(long double ldval, std::string* value);

--- a/src/common.h
+++ b/src/common.h
@@ -145,7 +145,7 @@ inline std::size_t Number2Str(char* ptr, std::size_t nBytes, T val) {
   return off;
 }
 
-bool IsValidNumber(const std::string& str, std::size_t slen);
+bool IsValidNumber(const std::string& str);
 
 int Double2Str(char* ptr, std::size_t nBytes, double val);
 int StrToLongDouble(const char* s, size_t slen, long double* ldval);

--- a/src/common.h
+++ b/src/common.h
@@ -145,7 +145,7 @@ inline std::size_t Number2Str(char* ptr, std::size_t nBytes, T val) {
   return off;
 }
 
-bool IsValidNumber(const std::string& str);
+bool IsValidNumber(const PString& str);
 
 int Double2Str(char* ptr, std::size_t nBytes, double val);
 int StrToLongDouble(const char* s, size_t slen, long double* ldval);

--- a/src/pstring.cc
+++ b/src/pstring.cc
@@ -16,7 +16,8 @@ PObject PObject::CreateString(const PString& value) {
   PObject obj(kPTypeString);
 
   long val;
-  if (Strtol(value.c_str(), value.size(), &val)) {
+  if (IsValidNumber(value.c_str(), value.size())) {
+    Strtol(value.c_str(), value.size(), &val);
     obj.encoding = kPEncodeInt;
     obj.value = (void*)val;
     DEBUG("set long value {}", val);

--- a/src/pstring.cc
+++ b/src/pstring.cc
@@ -16,7 +16,7 @@ PObject PObject::CreateString(const PString& value) {
   PObject obj(kPTypeString);
 
   long val;
-  if (IsValidNumber(value.c_str(), value.size())) {
+  if (IsValidNumber(value.c_str())) {
     Strtol(value.c_str(), value.size(), &val);
     obj.encoding = kPEncodeInt;
     obj.value = (void*)val;

--- a/src/pstring.cc
+++ b/src/pstring.cc
@@ -16,7 +16,7 @@ PObject PObject::CreateString(const PString& value) {
   PObject obj(kPTypeString);
 
   long val;
-  if (IsValidNumber(value.c_str())) {
+  if (IsValidNumber(value)) {
     Strtol(value.c_str(), value.size(), &val);
     obj.encoding = kPEncodeInt;
     obj.value = (void*)val;

--- a/src/store.cc
+++ b/src/store.cc
@@ -567,11 +567,20 @@ PError PStore::Incrby(const PString& key, int64_t value, int64_t* ret) {
   if (err != kPErrorOK) {
     return err;
   }
-  char* end = nullptr;
+
   auto str = pikiwidb::GetDecodedString(old_value);
-  int64_t ival = strtoll(str->c_str(), &end, 10);
-  if (*end != 0) {
+  if (!IsValidNumber(str->c_str(), str->size())) {
     // value is not a integer
+    return kPErrorType;
+  }
+
+  int64_t ival = 0;
+  std::string::size_type end = 0;  // alias of size_t
+  try {
+    ival = std::stoll(str->c_str(), &end, 0);
+  } catch (const std::out_of_range& e) {
+    return kPErrorOverflow;
+  } catch (...) {
     return kPErrorType;
   }
 
@@ -602,8 +611,13 @@ PError PStore::Decrby(const PString& key, int64_t value, int64_t* ret) {
   }
   auto str = pikiwidb::GetDecodedString(old_value);
 
-  std::string::size_type end = 0;  // alias of size_t
+  if (!IsValidNumber(str->c_str(), str->size())) {
+    // value is not a integer
+    return kPErrorType;
+  }
+
   int64_t ival = 0;
+  std::string::size_type end = 0;  // alias of size_t
   try {
     ival = std::stoll(str->c_str(), &end, 0);
   } catch (const std::out_of_range& e) {

--- a/src/store.cc
+++ b/src/store.cc
@@ -569,7 +569,7 @@ PError PStore::Incrby(const PString& key, int64_t value, int64_t* ret) {
   }
 
   auto str = pikiwidb::GetDecodedString(old_value);
-  if (!IsValidNumber(str->c_str())) {
+  if (!IsValidNumber(*str)) {
     // value is not a integer
     return kPErrorType;
   }
@@ -611,7 +611,7 @@ PError PStore::Decrby(const PString& key, int64_t value, int64_t* ret) {
   }
   auto str = pikiwidb::GetDecodedString(old_value);
 
-  if (!IsValidNumber(str->c_str())) {
+  if (!IsValidNumber(*str)) {
     // value is not a integer
     return kPErrorType;
   }

--- a/src/store.cc
+++ b/src/store.cc
@@ -569,7 +569,7 @@ PError PStore::Incrby(const PString& key, int64_t value, int64_t* ret) {
   }
 
   auto str = pikiwidb::GetDecodedString(old_value);
-  if (!IsValidNumber(str->c_str(), str->size())) {
+  if (!IsValidNumber(str->c_str())) {
     // value is not a integer
     return kPErrorType;
   }
@@ -611,7 +611,7 @@ PError PStore::Decrby(const PString& key, int64_t value, int64_t* ret) {
   }
   auto str = pikiwidb::GetDecodedString(old_value);
 
-  if (!IsValidNumber(str->c_str(), str->size())) {
+  if (!IsValidNumber(str->c_str())) {
     // value is not a integer
     return kPErrorType;
   }


### PR DESCRIPTION
fixed the issue where the set command would encounter a conversion error under specific strings `(e.g. "0123", "0x23")`, resulting in an inconsistent value for set. 

After the fix, the result is as follows:

if str is valid number :
![CleanShot 2023-12-20 at 13 35 14@2x](https://github.com/OpenAtomFoundation/pikiwidb/assets/51713304/5e5e0ed7-1fed-45e7-9e97-e7464fafbbd6)

Other strings (even if they are in octal or decimal) will also be recognized as non-numeric and stored using "string"：
![CleanShot 2023-12-20 at 13 37 25@2x](https://github.com/OpenAtomFoundation/pikiwidb/assets/51713304/1e446ce5-e9e0-4d36-9d14-533c0313bfa7)

and also fixed errors in commands like `incr`, `incrby`, etc. :
![CleanShot 2023-12-20 at 13 39 36@2x](https://github.com/OpenAtomFoundation/pikiwidb/assets/51713304/61b3229b-68e8-4c4a-9423-bd87ddbfd77e)

when the value is a valid number, the above command will be executed normally:
![CleanShot 2023-12-20 at 13 40 45@2x](https://github.com/OpenAtomFoundation/pikiwidb/assets/51713304/1d6dad85-f5c7-4fcc-af00-3d68bad73215)
