### PR TITLE
fix: fix the string out-of-bounds issue without handling it correctly

### DIFF
--- a/src/common.cc
+++ b/src/common.cc
@@ -47,7 +47,7 @@ struct PErrorInfo g_errorInfo[] = {
 
 bool IsValidNumber(const PString& str) {
   size_t slen = str.size();
-  if (slen == 0 || slen >= 20 || (str[0] != '-' && !isdigit(str[0]))) {
+  if (slen == 0 || slen > 20 || (str[0] != '-' && !isdigit(str[0]))) {
     return false;
   }
 

--- a/src/pstring.cc
+++ b/src/pstring.cc
@@ -14,10 +14,11 @@ namespace pikiwidb {
 
 PObject PObject::CreateString(const PString& value) {
   PObject obj(kPTypeString);
-
   long val;
-  if (IsValidNumber(value)) {
-    Strtol(value.c_str(), value.size(), &val);
+
+  // isVaildNumber ensures that the string is in decimal format,
+  // while strtol ensures that the string is within the range of long type
+  if (IsValidNumber(value) && Strtol(value.c_str(), value.size(), &val)) {
     obj.encoding = kPEncodeInt;
     obj.value = (void*)val;
     DEBUG("set long value {}", val);


### PR DESCRIPTION
fix the issue of not properly handling strings when they go out of bounds
before repair: 
<img width="330" alt="CleanShot 2024-01-02 at 00 12 42@2x" src="https://github.com/OpenAtomFoundation/pikiwidb/assets/51713304/bdc01876-c349-41ee-aa63-a2bf4315426e">

after:
<img width="395" alt="CleanShot 2024-01-02 at 00 16 04@2x" src="https://github.com/OpenAtomFoundation/pikiwidb/assets/51713304/50b58d85-386e-4c11-85ea-6ff4ac7784f4">
