### PR TITLE
fix:resp protocol empty array format

### DIFF
--- a/src/client.cc
+++ b/src/client.cc
@@ -28,7 +28,7 @@ void CmdRes::RedisAppendLen(std::string& str, int64_t ori, const std::string& pr
 
 void CmdRes::AppendStringVector(const std::vector<std::string>& strArray) {
   if (strArray.empty()) {
-    AppendArrayLen(-1);
+    AppendArrayLen(0);
     return;
   }
   AppendArrayLen(static_cast<int64_t>(strArray.size()));


### PR DESCRIPTION
修复resp 空数组返回的格式