### PR TITLE
fix: floyd keys command

### DIFF
--- a/src/storage/include/storage/storage.h
+++ b/src/storage/include/storage/storage.h
@@ -23,6 +23,7 @@
 #include "rocksdb/table.h"
 
 #include "pstd/pstd_mutex.h"
+#include "src/lock_mgr.h"
 #include "storage/slot_indexer.h"
 
 namespace storage {
@@ -1078,6 +1079,9 @@ class Storage {
   std::vector<std::unique_ptr<Redis>> insts_;
   std::unique_ptr<SlotIndexer> slot_indexer_;
   std::atomic<bool> is_opened_ = false;
+  std::shared_ptr<LockMgr> lock_mgr_;
+  std::mutex snapshots_protector_;
+  std::vector<const rocksdb::Snapshot*> snapshots_;
 
   std::unique_ptr<LRUCache<std::string, std::string>> cursors_store_;
 

--- a/src/storage/src/redis.h
+++ b/src/storage/src/redis.h
@@ -218,8 +218,8 @@ class Redis {
   Status SInter(const std::vector<std::string>& keys, std::vector<std::string>* members);
   Status SInterstore(const Slice& destination, const std::vector<std::string>& keys,
                      std::vector<std::string>& value_to_dest, int32_t* ret);
-  Status SIsmember(const Slice& key, const Slice& member, int32_t* ret);
-  Status SMembers(const Slice& key, std::vector<std::string>* members);
+  Status SIsmember(const Slice& key, const Slice& member, int32_t* ret, const rocksdb::Snapshot* snapshot);
+  Status SMembers(const Slice& key, std::vector<std::string>* members, const rocksdb::Snapshot* snapshot);
   Status SMembersWithTTL(const Slice& key, std::vector<std::string>* members, uint64_t* ttl);
   Status SMove(const Slice& source, const Slice& destination, const Slice& member, int32_t* ret);
   Status SPop(const Slice& key, std::vector<std::string>* members, int64_t cnt);
@@ -269,8 +269,9 @@ class Redis {
   Status ZRevrangebyscore(const Slice& key, double min, double max, bool left_close, bool right_close, int64_t count,
                           int64_t offset, std::vector<ScoreMember>* score_members);
   Status ZRevrank(const Slice& key, const Slice& member, int32_t* rank);
-  Status ZScore(const Slice& key, const Slice& member, double* score);
-  Status ZGetAll(const Slice& key, double weight, std::map<std::string, double>* value_to_dest);
+  Status ZScore(const Slice& key, const Slice& member, double* score, const rocksdb::Snapshot* snapshot);
+  Status ZGetAll(const Slice& key, double weight, std::map<std::string, double>* value_to_dest,
+                 const rocksdb::Snapshot* snapshot);
   Status ZUnionstore(const Slice& destination, const std::vector<std::string>& keys, const std::vector<double>& weights,
                      AGGREGATE agg, std::map<std::string, double>& value_to_dest, int32_t* ret);
   Status ZInterstore(const Slice& destination, const std::vector<std::string>& keys, const std::vector<double>& weights,

--- a/src/storage/src/redis_sets.cc
+++ b/src/storage/src/redis_sets.cc
@@ -570,14 +570,13 @@ rocksdb::Status Redis::SInterstore(const Slice& destination, const std::vector<s
   return s;
 }
 
-rocksdb::Status Redis::SIsmember(const Slice& key, const Slice& member, int32_t* ret) {
+rocksdb::Status Redis::SIsmember(const Slice& key, const Slice& member, int32_t* ret,
+                                 const rocksdb::Snapshot* snapshot) {
   *ret = 0;
   rocksdb::ReadOptions read_options;
-  const rocksdb::Snapshot* snapshot;
 
   std::string meta_value;
   uint64_t version = 0;
-  ScopeSnapshot ss(db_, &snapshot);
   read_options.snapshot = snapshot;
 
   BaseMetaKey base_meta_key(key);
@@ -601,13 +600,11 @@ rocksdb::Status Redis::SIsmember(const Slice& key, const Slice& member, int32_t*
   return s;
 }
 
-rocksdb::Status Redis::SMembers(const Slice& key, std::vector<std::string>* members) {
+rocksdb::Status Redis::SMembers(const Slice& key, std::vector<std::string>* members,
+                                const rocksdb::Snapshot* snapshot) {
   rocksdb::ReadOptions read_options;
-  const rocksdb::Snapshot* snapshot;
-
   std::string meta_value;
   uint64_t version = 0;
-  ScopeSnapshot ss(db_, &snapshot);
   read_options.snapshot = snapshot;
 
   BaseMetaKey base_meta_key(key);

--- a/src/storage/src/redis_zsets.cc
+++ b/src/storage/src/redis_zsets.cc
@@ -1014,13 +1014,10 @@ Status Redis::ZRevrank(const Slice& key, const Slice& member, int32_t* rank) {
   return s;
 }
 
-Status Redis::ZScore(const Slice& key, const Slice& member, double* score) {
+Status Redis::ZScore(const Slice& key, const Slice& member, double* score, const rocksdb::Snapshot* snapshot) {
   *score = 0;
   rocksdb::ReadOptions read_options;
-  const rocksdb::Snapshot* snapshot = nullptr;
-
   std::string meta_value;
-  ScopeSnapshot ss(db_, &snapshot);
   read_options.snapshot = snapshot;
 
   BaseMetaKey base_meta_key(key);
@@ -1052,11 +1049,10 @@ Status Redis::ZScore(const Slice& key, const Slice& member, double* score) {
   return s;
 }
 
-Status Redis::ZGetAll(const Slice& key, double weight, std::map<std::string, double>* value_to_dest) {
+Status Redis::ZGetAll(const Slice& key, double weight, std::map<std::string, double>* value_to_dest,
+                      const rocksdb::Snapshot* snapshot) {
   Status s;
   rocksdb::ReadOptions read_options;
-  const rocksdb::Snapshot* snapshot = nullptr;
-  ScopeSnapshot ss(db_, &snapshot);
   read_options.snapshot = snapshot;
   std::string meta_value;
 


### PR DESCRIPTION
#154 
在这个 PR 中，我们将 `Snapshots` 移到了 `storage` 层，即我们在 `storage` 层做好对于多个 `Key` 命令的快照处理，我们使用了两种类型的锁来确保操作多个 `Key` 时的一致性，一种是 `pstd::lock::MultiRecordLock record_lock(lock_mgr_);` 这种 `Key` 锁确保操作多个 `Key` 时进行上互斥操作，一种是 `std::unique_lock<std::mutex> lock(snapshots_protector_)` 这种互斥锁用来保护 `snapshots` 操作，当每次对快照处理完之后，我们就会对这两把锁进行解锁，不影响剩下的计算流程，这两把锁是用来处理执行 `snapshots` 的操作。

我们以 `Sinterstore` 命令举例：
我们会先执行 `Inster` 操作去计算有交集的 `Key`，然后对要写到的 `destination` 的这个 `Key` 先上一个 `Key` 锁，然后将计算到交集数据写进这个 `Key`.
>
<img width="740" alt="截屏2024-01-30 17 35 14" src="https://github.com/OpenAtomFoundation/pikiwidb/assets/73943232/a12065d5-5685-482f-869a-5b475dbb3f9f">

>
>
>
>
对于 `Inster` 操作，我们先对需要进行计算的多个 `Key` 进行上 `Key` 锁，然后再上一层 `snapshots_protector`的保护 `snapshots`的互斥锁，然后进行相应 `RocksDB` 的 Snapshots` 计算，然后计算完之后对这两个锁进行解锁操作.
>
<img width="787" alt="截屏2024-01-30 17 39 51" src="https://github.com/OpenAtomFoundation/pikiwidb/assets/73943232/745082b3-e4d8-44ee-abe9-3e97331df647">
