### PR TITLE
fix:hashscan_bug_fix

### DIFF
--- a/src/storage/src/redis_hashes.cc
+++ b/src/storage/src/redis_hashes.cc
@@ -33,7 +33,7 @@ Status Redis::ScanHashesKeyNum(KeyInfo* key_info) {
   int64_t curtime;
   rocksdb::Env::Default()->GetCurrentTime(&curtime);
 
-  rocksdb::Iterator* iter = db_->NewIterator(iterator_options, handles_[kHashesDataCF]);
+  rocksdb::Iterator* iter = db_->NewIterator(iterator_options, handles_[kHashesMetaCF]);
   for (iter->SeekToFirst(); iter->Valid(); iter->Next()) {
     ParsedHashesMetaValue parsed_hashes_meta_value(iter->value());
     if (parsed_hashes_meta_value.IsStale() || parsed_hashes_meta_value.Count() == 0) {


### PR DESCRIPTION
修复hash类型san接口统计的column-family错误的问题。
from pr : https://github.com/OpenAtomFoundation/pika/pull/2385
todo : 
flush 命令在实现时要注意不再支持 flush type 操作。