### PR TITLE
fix:multiple threads write data, pointer error

### DIFF
--- a/src/cmd_kv.cc
+++ b/src/cmd_kv.cc
@@ -577,7 +577,8 @@ void SetRangeCmd::DoCmd(PClient* client) {
   }
 
   int32_t ret = 0;
-  storage::Status s = PSTORE.GetBackend(client->GetCurrentDB())->Setrange(client->Key(), offset, client->argv_[3], &ret);
+  storage::Status s =
+      PSTORE.GetBackend(client->GetCurrentDB())->Setrange(client->Key(), offset, client->argv_[3], &ret);
   if (!s.ok()) {
     client->SetRes(CmdRes::kErrOther, "setrange cmd error");
     return;

--- a/src/cmd_kv.cc
+++ b/src/cmd_kv.cc
@@ -510,7 +510,7 @@ void GetRangeCmd::DoCmd(PClient* client) {
   int64_t end = 0;
   pstd::String2int(client->argv_[2].data(), client->argv_[2].size(), &start);
   pstd::String2int(client->argv_[3].data(), client->argv_[3].size(), &end);
-  auto s = PSTORE.GetBackend()->Getrange(client->Key(), start, end, &ret);
+  auto s = PSTORE.GetBackend(client->GetCurrentDB())->Getrange(client->Key(), start, end, &ret);
   if (!s.ok()) {
     if (s.IsNotFound()) {
       client->AppendString("");
@@ -577,7 +577,7 @@ void SetRangeCmd::DoCmd(PClient* client) {
   }
 
   int32_t ret = 0;
-  storage::Status s = PSTORE.GetBackend()->Setrange(client->Key(), offset, client->argv_[3], &ret);
+  storage::Status s = PSTORE.GetBackend(client->GetCurrentDB())->Setrange(client->Key(), offset, client->argv_[3], &ret);
   if (!s.ok()) {
     client->SetRes(CmdRes::kErrOther, "setrange cmd error");
     return;

--- a/src/cmd_list.cc
+++ b/src/cmd_list.cc
@@ -86,7 +86,7 @@ void LRemCmd::DoCmd(PClient* client) {
   }
 
   uint64_t reply_num = 0;
-  storage::Status s = PSTORE.GetBackend()->LRem(client->Key(), freq_, client->argv_[3], &reply_num);
+  storage::Status s = PSTORE.GetBackend(client->GetCurrentDB())->LRem(client->Key(), freq_, client->argv_[3], &reply_num);
   if (s.ok() || s.IsNotFound()) {
     client->AppendInteger(reply_num);
   } else {

--- a/src/cmd_list.cc
+++ b/src/cmd_list.cc
@@ -86,7 +86,8 @@ void LRemCmd::DoCmd(PClient* client) {
   }
 
   uint64_t reply_num = 0;
-  storage::Status s = PSTORE.GetBackend(client->GetCurrentDB())->LRem(client->Key(), freq_, client->argv_[3], &reply_num);
+  storage::Status s =
+      PSTORE.GetBackend(client->GetCurrentDB())->LRem(client->Key(), freq_, client->argv_[3], &reply_num);
   if (s.ok() || s.IsNotFound()) {
     client->AppendInteger(reply_num);
   } else {


### PR DESCRIPTION
修复多线程下,网络写入指针错误.

libevent 中 多线程写入需要异步写入, 但是之前的 `data` 指针 因为异步的原因, 会导致原来的数据先被释放了,所以写入的数据会出错. 现在在写入前, 先复制了一份,保证不会出错