### PR TITLE
feat:Support network read/write separation and command thread pool

### DIFF
--- a/src/base_cmd.cc
+++ b/src/base_cmd.cc
@@ -15,8 +15,8 @@ BaseCmd::BaseCmd(std::string name, int16_t arity, uint32_t flag, uint32_t aclCat
   name_ = std::move(name);
   arity_ = arity;
   flag_ = flag;
-  aclCategory_ = aclCategory;
-  cmdID_ = g_pikiwidb->GetCmdID();
+  acl_category_ = aclCategory;
+  cmd_id_ = g_pikiwidb->GetCmdID();
 }
 
 bool BaseCmd::CheckArg(size_t num) const {
@@ -46,13 +46,13 @@ void BaseCmd::SetFlag(uint32_t flag) { flag_ |= flag; }
 void BaseCmd::ResetFlag(uint32_t flag) { flag_ &= ~flag; }
 bool BaseCmd::HasSubCommand() const { return false; }
 BaseCmd* BaseCmd::GetSubCmd(const std::string& cmdName) { return nullptr; }
-uint32_t BaseCmd::AclCategory() const { return aclCategory_; }
-void BaseCmd::AddAclCategory(uint32_t aclCategory) { aclCategory_ |= aclCategory; }
+uint32_t BaseCmd::AclCategory() const { return acl_category_; }
+void BaseCmd::AddAclCategory(uint32_t aclCategory) { acl_category_ |= aclCategory; }
 std::string BaseCmd::Name() const { return name_; }
 // CmdRes& BaseCommand::Res() { return res_; }
 // void BaseCommand::SetResp(const std::shared_ptr<std::string>& resp) { resp_ = resp; }
 // std::shared_ptr<std::string> BaseCommand::GetResp() { return resp_.lock(); }
-uint32_t BaseCmd::GetCmdID() const { return cmdID_; }
+uint32_t BaseCmd::GetCmdID() const { return cmd_id_; }
 
 // BaseCmdGroup
 BaseCmdGroup::BaseCmdGroup(const std::string& name, uint32_t flag) : BaseCmdGroup(name, -2, flag) {}

--- a/src/base_cmd.cc
+++ b/src/base_cmd.cc
@@ -16,7 +16,7 @@ BaseCmd::BaseCmd(std::string name, int16_t arity, uint32_t flag, uint32_t aclCat
   arity_ = arity;
   flag_ = flag;
   aclCategory_ = aclCategory;
-  cmdID_ = g_pikiwidb->GetCmdId();
+  cmdID_ = g_pikiwidb->GetCmdID();
 }
 
 bool BaseCmd::CheckArg(size_t num) const {

--- a/src/base_cmd.cc
+++ b/src/base_cmd.cc
@@ -16,7 +16,7 @@ BaseCmd::BaseCmd(std::string name, int16_t arity, uint32_t flag, uint32_t aclCat
   arity_ = arity;
   flag_ = flag;
   aclCategory_ = aclCategory;
-  cmdId_ = g_pikiwidb->GetCmdId();
+  cmdID_ = g_pikiwidb->GetCmdId();
 }
 
 bool BaseCmd::CheckArg(size_t num) const {
@@ -52,7 +52,7 @@ std::string BaseCmd::Name() const { return name_; }
 // CmdRes& BaseCommand::Res() { return res_; }
 // void BaseCommand::SetResp(const std::shared_ptr<std::string>& resp) { resp_ = resp; }
 // std::shared_ptr<std::string> BaseCommand::GetResp() { return resp_.lock(); }
-uint32_t BaseCmd::GetCmdId() const { return cmdId_; }
+uint32_t BaseCmd::GetCmdID() const { return cmdID_; }
 
 // BaseCmdGroup
 BaseCmdGroup::BaseCmdGroup(const std::string& name, uint32_t flag) : BaseCmdGroup(name, -2, flag) {}

--- a/src/base_cmd.cc
+++ b/src/base_cmd.cc
@@ -16,7 +16,7 @@ BaseCmd::BaseCmd(std::string name, int16_t arity, uint32_t flag, uint32_t aclCat
   arity_ = arity;
   flag_ = flag;
   aclCategory_ = aclCategory;
-  cmdId_ = g_pikiwidb->GetCmdTableManager().GetCmdId();
+  cmdId_ = g_pikiwidb->GetCmdId();
 }
 
 bool BaseCmd::CheckArg(size_t num) const {

--- a/src/base_cmd.h
+++ b/src/base_cmd.h
@@ -275,8 +275,8 @@ class BaseCmd : public std::enable_shared_from_this<BaseCmd> {
   //  std::weak_ptr<std::string> resp_;
   //  uint64_t doDuration_ = 0;
 
-  uint32_t cmdID_ = 0;
-  uint32_t aclCategory_ = 0;
+  uint32_t cmd_id_ = 0;
+  uint32_t acl_category_ = 0;
 
  private:
   // The function to be executed first before executing `DoCmd`

--- a/src/base_cmd.h
+++ b/src/base_cmd.h
@@ -259,7 +259,7 @@ class BaseCmd : public std::enable_shared_from_this<BaseCmd> {
   //  void SetResp(const std::shared_ptr<std::string>& resp);
   //  std::shared_ptr<std::string> GetResp();
 
-  uint32_t GetCmdId() const;
+  uint32_t GetCmdID() const;
 
  protected:
   // Execute a specific command
@@ -275,7 +275,7 @@ class BaseCmd : public std::enable_shared_from_this<BaseCmd> {
   //  std::weak_ptr<std::string> resp_;
   //  uint64_t doDuration_ = 0;
 
-  uint32_t cmdId_ = 0;
+  uint32_t cmdID_ = 0;
   uint32_t aclCategory_ = 0;
 
  private:

--- a/src/client.cc
+++ b/src/client.cc
@@ -289,7 +289,7 @@ int PClient::handlePacket(const char* start, int bytes) {
     return static_cast<int>(ptr - start);
   }
 
-  DEFER { reset(); };
+  //  DEFER { reset(); };
 
   // handle packet
   //  const auto& params = parser_.GetParams();
@@ -495,15 +495,17 @@ bool PClient::SendPacket(const evbuffer_iovec* iovecs, size_t nvecs) {
   return false;
 }
 
-void PClient::WriteReply2Net() {
+void PClient::WriteReply2Client() {
   if (auto c = getTcpConnection(); c) {
     c->SendPacket(Message());
   }
   Clear();
+  reset();
 }
 
 void PClient::Close() {
   SetState(ClientState::kClosed);
+  reset();
   if (auto c = getTcpConnection(); c) {
     c->ActiveClose();
     tcp_connection_.reset();

--- a/src/client.cc
+++ b/src/client.cc
@@ -329,9 +329,11 @@ int PClient::handlePacket(const char* start, int bytes) {
   //  const PCommandInfo* info = PCommandTable::GetCommandInfo(cmdName_);
 
   //  if (!info) {  // 如果这个命令不存在，那么就走新的命令处理流程
-  executeCommand();
+  //  executeCommand();
   //    return static_cast<int>(ptr - start);
   //  }
+
+  g_pikiwidb->SubmitFast(std::make_shared<CmdThreadPoolTask>(shared_from_this()));
 
   // check transaction
   //  if (IsFlagOn(ClientFlag_multi)) {
@@ -376,24 +378,24 @@ int PClient::handlePacket(const char* start, int bytes) {
 // 为了兼容老的命令处理流程，新的命令处理流程在这里
 // 后面可以把client这个类重构，完整的支持新的命令处理流程
 void PClient::executeCommand() {
-  auto [cmdPtr, ret] = g_pikiwidb->GetCmdTableManager().GetCommand(CmdName(), this);
+  //  auto [cmdPtr, ret] = g_pikiwidb->GetCmdTableManager().GetCommand(CmdName(), this);
 
-  if (!cmdPtr) {
-    if (ret == CmdRes::kInvalidParameter) {
-      SetRes(CmdRes::kInvalidParameter);
-    } else {
-      SetRes(CmdRes::kSyntaxErr, "unknown command '" + CmdName() + "'");
-    }
-    return;
-  }
-
-  if (!cmdPtr->CheckArg(params_.size())) {
-    SetRes(CmdRes::kWrongNum, CmdName());
-    return;
-  }
-
-  // execute a specific command
-  cmdPtr->Execute(this);
+  //  if (!cmdPtr) {
+  //    if (ret == CmdRes::kInvalidParameter) {
+  //      SetRes(CmdRes::kInvalidParameter);
+  //    } else {
+  //      SetRes(CmdRes::kSyntaxErr, "unknown command '" + CmdName() + "'");
+  //    }
+  //    return;
+  //  }
+  //
+  //  if (!cmdPtr->CheckArg(params_.size())) {
+  //    SetRes(CmdRes::kWrongNum, CmdName());
+  //    return;
+  //  }
+  //
+  //  // execute a specific command
+  //  cmdPtr->Execute(this);
 }
 
 PClient* PClient::Current() { return s_current; }
@@ -420,13 +422,14 @@ int PClient::HandlePackets(pikiwidb::TcpConnection* obj, const char* start, int 
     total += processed;
   }
 
-  obj->SendPacket(Message());
-  Clear();
+  //  obj->SendPacket(Message());
+  //  Clear();
   //  reply_.Clear();
   return total;
 }
 
 void PClient::OnConnect() {
+  SetState(ClientState::kOK);
   if (isPeerMaster()) {
     PREPL.SetMasterState(kPReplStateConnected);
     PREPL.SetMaster(std::static_pointer_cast<PClient>(shared_from_this()));
@@ -492,7 +495,15 @@ bool PClient::SendPacket(const evbuffer_iovec* iovecs, size_t nvecs) {
   return false;
 }
 
+void PClient::WriteReply2Net() {
+  if (auto c = getTcpConnection(); c) {
+    c->SendPacket(Message());
+  }
+  Clear();
+}
+
 void PClient::Close() {
+  SetState(ClientState::kClosed);
   if (auto c = getTcpConnection(); c) {
     c->ActiveClose();
     tcp_connection_.reset();

--- a/src/client.cc
+++ b/src/client.cc
@@ -449,7 +449,7 @@ void PClient::OnConnect() {
 
 const std::string& PClient::PeerIP() const {
   if (auto c = getTcpConnection(); c) {
-    return c->GetPeerIp();
+    return c->GetPeerIP();
   }
 
   static const std::string kEmpty;

--- a/src/client.h
+++ b/src/client.h
@@ -126,7 +126,7 @@ class PClient : public std::enable_shared_from_this<PClient>, public CmdRes {
   bool SendPacket(UnboundedBuffer& data);
   bool SendPacket(const evbuffer_iovec* iovecs, size_t nvecs);
 
-  void WriteReply2Net();
+  void WriteReply2Client();
 
   void Close();
 

--- a/src/client.h
+++ b/src/client.h
@@ -101,6 +101,11 @@ enum ClientFlag {
   kClientFlagMaster = (1 << 3),
 };
 
+enum class ClientState {
+  kOK,
+  kClosed,
+};
+
 class DB;
 struct PSlaveInfo;
 
@@ -120,6 +125,8 @@ class PClient : public std::enable_shared_from_this<PClient>, public CmdRes {
   bool SendPacket(const void* data, size_t size);
   bool SendPacket(UnboundedBuffer& data);
   bool SendPacket(const evbuffer_iovec* iovecs, size_t nvecs);
+
+  void WriteReply2Net();
 
   void Close();
 
@@ -196,6 +203,12 @@ class PClient : public std::enable_shared_from_this<PClient>, public CmdRes {
   bool GetAuth() const { return auth_; }
   void RewriteCmd(std::vector<std::string>& params) { parser_.SetParams(params); }
 
+  inline size_t ParamsSize() const { return params_.size(); }
+
+  inline ClientState State() const { return state_; }
+
+  inline void SetState(ClientState state) { state_ = state; }
+
   // All parameters of this command (including the command itself)
   // e.g：["set","key","value"]
   std::span<std::string> argv_;
@@ -244,6 +257,8 @@ class PClient : public std::enable_shared_from_this<PClient>, public CmdRes {
   // auth
   bool auth_ = false;
   time_t last_auth_ = 0;
+
+  ClientState state_;
 
   static thread_local PClient* s_current;
 };

--- a/src/cmd_thread_pool.cc
+++ b/src/cmd_thread_pool.cc
@@ -18,7 +18,7 @@ std::shared_ptr<PClient> CmdThreadPoolTask::Client() { return client_; }
 CmdThreadPool::CmdThreadPool(std::string name) : name_(std::move(name)) {}
 
 pstd::Status CmdThreadPool::Init(int fastThread, int slowThread, std::string name) {
-  if (fastThread < 0) {
+  if (fastThread <= 0) {
     return pstd::Status::InvalidArgument("thread num must be positive");
   }
   name_ = std::move(name);

--- a/src/cmd_thread_pool.cc
+++ b/src/cmd_thread_pool.cc
@@ -58,9 +58,9 @@ void CmdThreadPool::SubmitSlow(const std::shared_ptr<CmdThreadPoolTask> &runner)
   slowCondition_.notify_one();
 }
 
-void CmdThreadPool::Stop() { doStop(); }
+void CmdThreadPool::Stop() { DoStop(); }
 
-void CmdThreadPool::doStop() {
+void CmdThreadPool::DoStop() {
   if (stopped_.load()) {
     return;
   }
@@ -90,6 +90,6 @@ void CmdThreadPool::doStop() {
   slowTasks_.clear();
 }
 
-CmdThreadPool::~CmdThreadPool() { doStop(); }
+CmdThreadPool::~CmdThreadPool() { DoStop(); }
 
 }  // namespace pikiwidb

--- a/src/cmd_thread_pool.cc
+++ b/src/cmd_thread_pool.cc
@@ -35,14 +35,14 @@ void CmdThreadPool::Start() {
     std::thread thread(&CmdWorkThreadPoolWorker::Work, fastWorker);
     threads_.emplace_back(std::move(thread));
     workers_.emplace_back(fastWorker);
-    INFO("fast worker [{}] starting ...", std::to_string(i));
+    INFO("fast worker [{}] starting ...", i);
   }
   for (int i = 0; i < slowThreadNum_; ++i) {
     auto slowWorker = std::make_shared<CmdSlowWorker>(this, 2, "slow worker" + std::to_string(i));
     std::thread thread(&CmdWorkThreadPoolWorker::Work, slowWorker);
     threads_.emplace_back(std::move(thread));
     workers_.emplace_back(slowWorker);
-    INFO("slow worker [{}] starting ...", std::to_string(i));
+    INFO("slow worker [{}] starting ...", i);
   }
 }
 

--- a/src/cmd_thread_pool.cc
+++ b/src/cmd_thread_pool.cc
@@ -18,7 +18,7 @@ std::shared_ptr<PClient> CmdThreadPoolTask::Client() { return client_; }
 CmdThreadPool::CmdThreadPool(std::string name) : name_(std::move(name)) {}
 
 pstd::Status CmdThreadPool::Init(int fastThread, int slowThread, std::string name) {
-  if (fastThread < 0 || slowThread < 0) {
+  if (fastThread < 0) {
     return pstd::Status::InvalidArgument("thread num must be positive");
   }
   name_ = std::move(name);

--- a/src/cmd_thread_pool.cc
+++ b/src/cmd_thread_pool.cc
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) 2023-present, Qihoo, Inc.  All rights reserved.
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+#include "cmd_thread_pool.h"
+#include "cmd_thread_pool_worker.h"
+#include "log.h"
+
+namespace pikiwidb {
+
+void CmdThreadPoolTask::Run(BaseCmd *cmd) { cmd->Execute(client_.get()); }
+const std::string &CmdThreadPoolTask::CmdName() { return client_->CmdName(); }
+std::shared_ptr<PClient> CmdThreadPoolTask::Client() { return client_; }
+
+CmdThreadPool::CmdThreadPool(std::string name) : name_(std::move(name)) {}
+
+pstd::Status CmdThreadPool::Init(int fastThread, int slowThread, std::string name) {
+  if (fastThread < 0 || slowThread < 0) {
+    return pstd::Status::InvalidArgument("thread num must be positive");
+  }
+  name_ = std::move(name);
+  fastThreadNum_ = fastThread;
+  slowThreadNum_ = slowThread;
+  thread_.reserve(fastThreadNum_ + slowThreadNum_);
+  return pstd::Status::OK();
+}
+
+void CmdThreadPool::Start() {
+  for (int i = 0; i < fastThreadNum_; ++i) {
+    std::jthread thread(&CmdWorkThreadPoolWorker::Work,
+                        std::make_shared<CmdFastWorker>(this, 2, "fast worker" + std::to_string(i)));
+    thread_.emplace_back(std::move(thread));
+    INFO("fast worker [{}] starting ...", std::to_string(i));
+  }
+  for (int i = 0; i < slowThreadNum_; ++i) {
+    std::jthread thread(&CmdWorkThreadPoolWorker::Work,
+                        std::make_shared<CmdSlowWorker>(this, 2, "slow worker" + std::to_string(i)));
+    thread_.emplace_back(std::move(thread));
+    INFO("slow worker [{}] starting ...", std::to_string(i));
+  }
+}
+
+void CmdThreadPool::SubmitFast(const std::shared_ptr<CmdThreadPoolTask> &runner) {
+  std::unique_lock rl(fastMutex_);
+  fastTasks_.emplace_back(runner);
+  fastCondition_.notify_one();
+}
+
+void CmdThreadPool::SubmitSlow(const std::shared_ptr<CmdThreadPoolTask> &runner) {
+  std::unique_lock rl(slowMutex_);
+  slowTasks_.emplace_back(runner);
+  slowCondition_.notify_one();
+}
+
+void CmdThreadPool::Stop() { doStop(); }
+
+void CmdThreadPool::doStop() {
+  if (stopped_.load()) {
+    return;
+  }
+  stopped_.store(true);
+
+  for (auto &thread : thread_) {
+    thread.request_stop();
+  }
+}
+
+CmdThreadPool::~CmdThreadPool() { doStop(); }
+
+}  // namespace pikiwidb

--- a/src/cmd_thread_pool.h
+++ b/src/cmd_thread_pool.h
@@ -48,7 +48,7 @@ class CmdThreadPool {
 
   explicit CmdThreadPool(std::string name);
 
-  pstd::Status Init(int fastThread, int slowThread, std::string name);
+  pstd::Status Init(int fast_thread, int slow_thread, std::string name);
 
   // start the thread pool
   void Start();
@@ -63,31 +63,32 @@ class CmdThreadPool {
   void SubmitSlow(const std::shared_ptr<CmdThreadPoolTask> &runner);
 
   // get the fast thread num
-  inline int FastThreadNum() const { return fastThreadNum_; };
+  inline int FastThreadNum() const { return fast_thread_num_; };
 
   // get the slow thread num
-  inline int SlowThreadNum() const { return slowThreadNum_; };
+  inline int SlowThreadNum() const { return slow_thread_num_; };
 
   // get the thread pool size
-  inline int ThreadPollSize() const { return fastThreadNum_ + slowThreadNum_; };
+  inline int ThreadPollSize() const { return fast_thread_num_ + slow_thread_num_; };
 
   ~CmdThreadPool();
 
  private:
   void DoStop();
 
-  std::deque<std::shared_ptr<CmdThreadPoolTask>> fastTasks_;  // fast task queue
-  std::deque<std::shared_ptr<CmdThreadPoolTask>> slowTasks_;  // slow task queue
+ private:
+  std::deque<std::shared_ptr<CmdThreadPoolTask>> fast_tasks_;  // fast task queue
+  std::deque<std::shared_ptr<CmdThreadPoolTask>> slow_tasks_;  // slow task queue
 
   std::vector<std::thread> threads_;
   std::vector<std::shared_ptr<CmdWorkThreadPoolWorker>> workers_;
   std::string name_;  // thread pool name
-  int fastThreadNum_ = 0;
-  int slowThreadNum_ = 0;
-  std::mutex fastMutex_;
-  std::condition_variable fastCondition_;
-  std::mutex slowMutex_;
-  std::condition_variable slowCondition_;
+  int fast_thread_num_ = 0;
+  int slow_thread_num_ = 0;
+  std::mutex fast_mutex_;
+  std::condition_variable fast_condition_;
+  std::mutex slow_mutex_;
+  std::condition_variable slow_condition_;
   std::atomic_bool stopped_ = false;
 };
 

--- a/src/cmd_thread_pool.h
+++ b/src/cmd_thread_pool.h
@@ -88,7 +88,7 @@ class CmdThreadPool {
   std::condition_variable fastCondition_;
   std::mutex slowMutex_;
   std::condition_variable slowCondition_;
-  std::atomic<bool> stopped_ = false;
+  std::atomic_bool stopped_ = false;
 };
 
 }  // namespace pikiwidb

--- a/src/cmd_thread_pool.h
+++ b/src/cmd_thread_pool.h
@@ -1,0 +1,93 @@
+/*
+ * Copyright (c) 2023-present, Qihoo, Inc.  All rights reserved.
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+#pragma once
+
+#include <condition_variable>
+#include <deque>
+#include <memory>
+#include <thread>
+#include <utility>
+#include <vector>
+#include "base_cmd.h"
+#include "pstd_status.h"
+
+namespace pikiwidb {
+
+// task interface
+// inherit this class and implement the Run method
+// then submit the task to the thread pool
+class CmdThreadPoolTask {
+ public:
+  CmdThreadPoolTask(std::shared_ptr<PClient> client) : client_(std::move(client)) {}
+  void Run(BaseCmd *cmd);
+  const std::string &CmdName();
+  std::shared_ptr<PClient> Client();
+
+ private:
+  std::shared_ptr<PClient> client_;
+};
+
+class CmdWorkThreadPoolWorker;
+
+class CmdFastWorker;
+
+class CmdSlowWorker;
+
+class CmdThreadPool {
+  friend CmdWorkThreadPoolWorker;
+  friend CmdFastWorker;
+  friend CmdSlowWorker;
+
+ public:
+  explicit CmdThreadPool() = default;
+
+  explicit CmdThreadPool(std::string name);
+
+  pstd::Status Init(int fastThread, int slowThread, std::string name);
+
+  // start the thread pool
+  void Start();
+
+  // submit a fast task to the thread pool
+  void SubmitFast(const std::shared_ptr<CmdThreadPoolTask> &runner);
+
+  // submit a slow task to the thread pool
+  void SubmitSlow(const std::shared_ptr<CmdThreadPoolTask> &runner);
+
+  // get the fast thread num
+  inline int FastThreadNum() const { return fastThreadNum_; };
+
+  // get the slow thread num
+  inline int SlowThreadNum() const { return slowThreadNum_; };
+
+  // get the thread pool size
+  inline int ThreadPollSize() const { return fastThreadNum_ + slowThreadNum_; };
+
+  // stop the thread pool
+  void Stop();
+
+  ~CmdThreadPool();
+
+ private:
+  void doStop();
+
+  std::deque<std::shared_ptr<CmdThreadPoolTask>> fastTasks_;  // fast task queue
+  std::deque<std::shared_ptr<CmdThreadPoolTask>> slowTasks_;  // slow task queue
+
+  std::vector<std::jthread> thread_;
+  std::string name_;  // thread pool name
+  int fastThreadNum_ = 0;
+  int slowThreadNum_ = 0;
+  std::mutex fastMutex_;
+  std::condition_variable fastCondition_;
+  std::mutex slowMutex_;
+  std::condition_variable slowCondition_;
+  std::atomic<bool> stopped_ = false;
+};
+
+}  // namespace pikiwidb

--- a/src/cmd_thread_pool.h
+++ b/src/cmd_thread_pool.h
@@ -74,7 +74,7 @@ class CmdThreadPool {
   ~CmdThreadPool();
 
  private:
-  void doStop();
+  void DoStop();
 
   std::deque<std::shared_ptr<CmdThreadPoolTask>> fastTasks_;  // fast task queue
   std::deque<std::shared_ptr<CmdThreadPoolTask>> slowTasks_;  // slow task queue

--- a/src/cmd_thread_pool.h
+++ b/src/cmd_thread_pool.h
@@ -53,6 +53,9 @@ class CmdThreadPool {
   // start the thread pool
   void Start();
 
+  // stop the thread pool
+  void Stop();
+
   // submit a fast task to the thread pool
   void SubmitFast(const std::shared_ptr<CmdThreadPoolTask> &runner);
 
@@ -68,9 +71,6 @@ class CmdThreadPool {
   // get the thread pool size
   inline int ThreadPollSize() const { return fastThreadNum_ + slowThreadNum_; };
 
-  // stop the thread pool
-  void Stop();
-
   ~CmdThreadPool();
 
  private:
@@ -79,7 +79,8 @@ class CmdThreadPool {
   std::deque<std::shared_ptr<CmdThreadPoolTask>> fastTasks_;  // fast task queue
   std::deque<std::shared_ptr<CmdThreadPoolTask>> slowTasks_;  // slow task queue
 
-  std::vector<std::jthread> thread_;
+  std::vector<std::thread> threads_;
+  std::vector<std::shared_ptr<CmdWorkThreadPoolWorker>> workers_;
   std::string name_;  // thread pool name
   int fastThreadNum_ = 0;
   int slowThreadNum_ = 0;

--- a/src/cmd_thread_pool_worker.cc
+++ b/src/cmd_thread_pool_worker.cc
@@ -40,7 +40,7 @@ void CmdWorkThreadPoolWorker::Work() {
     }
     selfTask_.clear();
   }
-  INFO("slow worker [{}] goodbye...", name_);
+  INFO("worker [{}] goodbye...", name_);
 }
 
 void CmdWorkThreadPoolWorker::Stop() { running_ = false; }
@@ -54,11 +54,12 @@ void CmdFastWorker::LoadWork() {
     pool_->fastCondition_.wait(lock);
   }
 
-  const auto num = std::min(static_cast<int>(pool_->fastTasks_.size()), onceTask_);
-  if (num > 0) {
-    std::move(pool_->fastTasks_.begin(), pool_->fastTasks_.begin() + num, std::back_inserter(selfTask_));
-    pool_->fastTasks_.erase(pool_->fastTasks_.begin(), pool_->fastTasks_.begin() + num);
+  if (pool_->fastTasks_.empty()) {
+    return;
   }
+  const auto num = std::min(static_cast<int>(pool_->fastTasks_.size()), onceTask_);
+  std::move(pool_->fastTasks_.begin(), pool_->fastTasks_.begin() + num, std::back_inserter(selfTask_));
+  pool_->fastTasks_.erase(pool_->fastTasks_.begin(), pool_->fastTasks_.begin() + num);
 }
 
 void CmdSlowWorker::LoadWork() {

--- a/src/cmd_thread_pool_worker.cc
+++ b/src/cmd_thread_pool_worker.cc
@@ -9,8 +9,6 @@
 #include "log.h"
 #include "pikiwidb.h"
 
-extern std::unique_ptr<PikiwiDB> g_pikiwidb;
-
 namespace pikiwidb {
 
 void CmdWorkThreadPoolWorker::Work() {
@@ -28,15 +26,16 @@ void CmdWorkThreadPoolWorker::Work() {
         } else {
           task->Client()->SetRes(CmdRes::kSyntaxErr, "unknown command '" + task->CmdName() + "'");
         }
-        goto END;
+        g_pikiwidb->PushWriteTask(task->Client());
+        continue;
       }
 
       if (!cmdPtr->CheckArg(task->Client()->ParamsSize())) {
         task->Client()->SetRes(CmdRes::kWrongNum, task->CmdName());
-        goto END;
+        g_pikiwidb->PushWriteTask(task->Client());
+        continue;
       }
       task->Run(cmdPtr);
-    END:
       g_pikiwidb->PushWriteTask(task->Client());
     }
     selfTask.clear();

--- a/src/cmd_thread_pool_worker.cc
+++ b/src/cmd_thread_pool_worker.cc
@@ -56,8 +56,10 @@ void CmdFastWorker::LoadWork() {
   }
 
   const auto num = std::min(static_cast<int>(pool_->fastTasks_.size()), onceTask_);
-  std::move(pool_->fastTasks_.begin(), pool_->fastTasks_.begin() + num, std::back_inserter(selfTask));
-  pool_->fastTasks_.erase(pool_->fastTasks_.begin(), pool_->fastTasks_.begin() + num);
+  if (num > 0) {
+    std::move(pool_->fastTasks_.begin(), pool_->fastTasks_.begin() + num, std::back_inserter(selfTask));
+    pool_->fastTasks_.erase(pool_->fastTasks_.begin(), pool_->fastTasks_.begin() + num);
+  }
 }
 
 void CmdSlowWorker::LoadWork() {
@@ -72,8 +74,11 @@ void CmdSlowWorker::LoadWork() {
     }
 
     const auto num = std::min(static_cast<int>(pool_->slowTasks_.size()), onceTask_);
-    std::move(pool_->slowTasks_.begin(), pool_->slowTasks_.begin() + num, std::back_inserter(selfTask));
-    pool_->slowTasks_.erase(pool_->slowTasks_.begin(), pool_->slowTasks_.begin() + num);
+    if (num > 0) {
+      std::move(pool_->slowTasks_.begin(), pool_->slowTasks_.begin() + num, std::back_inserter(selfTask));
+      pool_->slowTasks_.erase(pool_->slowTasks_.begin(), pool_->slowTasks_.begin() + num);
+      return;  // If the slow task is obtained, the fast task is no longer obtained
+    }
   }
 
   {
@@ -81,8 +86,10 @@ void CmdSlowWorker::LoadWork() {
     loopMore = true;
 
     const auto num = std::min(static_cast<int>(pool_->fastTasks_.size()), onceTask_);
-    std::move(pool_->fastTasks_.begin(), pool_->fastTasks_.begin() + num, std::back_inserter(selfTask));
-    pool_->fastTasks_.erase(pool_->fastTasks_.begin(), pool_->fastTasks_.begin() + num);
+    if (num > 0) {
+      std::move(pool_->fastTasks_.begin(), pool_->fastTasks_.begin() + num, std::back_inserter(selfTask));
+      pool_->fastTasks_.erase(pool_->fastTasks_.begin(), pool_->fastTasks_.begin() + num);
+    }
   }
 }
 

--- a/src/cmd_thread_pool_worker.cc
+++ b/src/cmd_thread_pool_worker.cc
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) 2023-present, Qihoo, Inc.  All rights reserved.
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+#include "cmd_thread_pool_worker.h"
+#include <iostream>
+#include "pikiwidb.h"
+
+extern std::unique_ptr<PikiwiDB> g_pikiwidb;
+
+namespace pikiwidb {
+
+void CmdWorkThreadPoolWorker::Work(const std::stop_token &stopToken) {
+  while (!stopToken.stop_requested()) {
+    LoadWork();
+    for (const auto &task : selfTask) {
+      if (task->Client()->State() != ClientState::kOK) {  // the client is closed
+        continue;
+      }
+      auto [cmdPtr, ret] = cmd_table_manager_.GetCommand(task->CmdName(), task->Client().get());
+
+      if (!cmdPtr) {
+        if (ret == CmdRes::kInvalidParameter) {
+          task->Client()->SetRes(CmdRes::kInvalidParameter);
+        } else {
+          task->Client()->SetRes(CmdRes::kSyntaxErr, "unknown command '" + task->CmdName() + "'");
+        }
+        goto END;
+      }
+
+      if (!cmdPtr->CheckArg(task->Client()->ParamsSize())) {
+        task->Client()->SetRes(CmdRes::kWrongNum, task->CmdName());
+        goto END;
+      }
+      task->Run(cmdPtr);
+    END:
+      g_pikiwidb->PushWriteTask(task->Client());
+    }
+    selfTask.clear();
+  }
+}
+
+void CmdFastWorker::LoadWork() {
+  std::unique_lock lock(pool_->fastMutex_);
+  while (pool_->fastTasks_.empty()) {
+    pool_->fastCondition_.wait(lock);
+  }
+
+  const auto num = std::min(static_cast<int>(pool_->fastTasks_.size()), onceTask_);
+  std::move(pool_->fastTasks_.begin(), pool_->fastTasks_.begin() + num, std::back_inserter(selfTask));
+  pool_->fastTasks_.erase(pool_->fastTasks_.begin(), pool_->fastTasks_.begin() + num);
+}
+
+void CmdSlowWorker::LoadWork() {
+  {
+    std::unique_lock lock(pool_->slowMutex_);
+    while (pool_->slowTasks_.empty() && loopMore) {  // loopMore is used to get the fast worker
+      pool_->slowCondition_.wait_for(lock, std::chrono::milliseconds(waitTime));
+      loopMore = false;
+    }
+
+    const auto num = std::min(static_cast<int>(pool_->slowTasks_.size()), onceTask_);
+    std::move(pool_->slowTasks_.begin(), pool_->slowTasks_.begin() + num, std::back_inserter(selfTask));
+    pool_->slowTasks_.erase(pool_->slowTasks_.begin(), pool_->slowTasks_.begin() + num);
+  }
+
+  {
+    std::unique_lock lock(pool_->fastMutex_);
+    loopMore = true;
+
+    const auto num = std::min(static_cast<int>(pool_->fastTasks_.size()), onceTask_);
+    std::move(pool_->fastTasks_.begin(), pool_->fastTasks_.begin() + num, std::back_inserter(selfTask));
+    pool_->fastTasks_.erase(pool_->fastTasks_.begin(), pool_->fastTasks_.begin() + num);
+  }
+}
+
+}  // namespace pikiwidb

--- a/src/cmd_thread_pool_worker.h
+++ b/src/cmd_thread_pool_worker.h
@@ -18,7 +18,7 @@ namespace pikiwidb {
 class CmdWorkThreadPoolWorker {
  public:
   explicit CmdWorkThreadPoolWorker(CmdThreadPool *pool, int onceTask, std::string name)
-      : pool_(pool), onceTask_(onceTask), name_(std::move(name)) {
+      : pool_(pool), once_task_(onceTask), name_(std::move(name)) {
     cmd_table_manager_.InitCmdTable();
   }
 
@@ -32,9 +32,9 @@ class CmdWorkThreadPoolWorker {
   virtual ~CmdWorkThreadPoolWorker() = default;
 
  protected:
-  std::vector<std::shared_ptr<CmdThreadPoolTask>> selfTask_;  // the task that the worker get from the thread pool
-  CmdThreadPool *pool_;
-  const int onceTask_ = 0;  // the max task num that the worker can get from the thread pool
+  std::vector<std::shared_ptr<CmdThreadPoolTask>> self_task_;  // the task that the worker get from the thread pool
+  CmdThreadPool *pool_ = nullptr;
+  const int once_task_ = 0;  // the max task num that the worker can get from the thread pool
   const std::string name_;
   bool running_ = true;
 
@@ -60,8 +60,8 @@ class CmdSlowWorker : public CmdWorkThreadPoolWorker {
   void LoadWork() override;
 
  private:
-  bool loopMore_ = false;  // When the slow queue is empty, try to get the fast queue
-  int waitTime_ = 200;     // When the slow queue is empty, wait 200 ms to check again
+  bool loop_more_ = false;  // When the slow queue is empty, try to get the fast queue
+  int wait_time_ = 200;     // When the slow queue is empty, wait 200 ms to check again
 };
 
 }  // namespace pikiwidb

--- a/src/cmd_thread_pool_worker.h
+++ b/src/cmd_thread_pool_worker.h
@@ -32,7 +32,7 @@ class CmdWorkThreadPoolWorker {
   virtual ~CmdWorkThreadPoolWorker() = default;
 
  protected:
-  std::vector<std::shared_ptr<CmdThreadPoolTask>> selfTask;  // the task that the worker get from the thread pool
+  std::vector<std::shared_ptr<CmdThreadPoolTask>> selfTask_;  // the task that the worker get from the thread pool
   CmdThreadPool *pool_;
   const int onceTask_ = 0;  // the max task num that the worker can get from the thread pool
   const std::string name_;
@@ -60,8 +60,8 @@ class CmdSlowWorker : public CmdWorkThreadPoolWorker {
   void LoadWork() override;
 
  private:
-  bool loopMore = false;
-  int waitTime = 200;
+  bool loopMore_ = false;
+  int waitTime_ = 200;
 };
 
 }  // namespace pikiwidb

--- a/src/cmd_thread_pool_worker.h
+++ b/src/cmd_thread_pool_worker.h
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2023-present, Qihoo, Inc.  All rights reserved.
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+#pragma once
+
+#include <memory>
+#include <utility>
+
+#include "cmd_table_manager.h"
+#include "cmd_thread_pool.h"
+
+namespace pikiwidb {
+
+class CmdWorkThreadPoolWorker {
+ public:
+  explicit CmdWorkThreadPoolWorker(CmdThreadPool *pool, int onceTask, std::string name)
+      : pool_(pool), onceTask_(onceTask), name_(std::move(name)) {
+    cmd_table_manager_.InitCmdTable();
+  }
+
+  void Work(const std::stop_token &stopToken);
+
+  // load the task from the thread pool
+  virtual void LoadWork() = 0;
+
+  virtual ~CmdWorkThreadPoolWorker() = default;
+
+ protected:
+  std::vector<std::shared_ptr<CmdThreadPoolTask>> selfTask;  // the task that the worker get from the thread pool
+  CmdThreadPool *pool_;
+  const int onceTask_ = 0;  // the max task num that the worker can get from the thread pool
+  const std::string name_;
+
+  pikiwidb::CmdTableManager cmd_table_manager_;
+};
+
+// fast worker
+class CmdFastWorker : public CmdWorkThreadPoolWorker {
+ public:
+  explicit CmdFastWorker(CmdThreadPool *pool, int onceTask, std::string name)
+      : CmdWorkThreadPoolWorker(pool, onceTask, std::move(name)) {}
+
+  void LoadWork() override;
+};
+
+// slow worker
+class CmdSlowWorker : public CmdWorkThreadPoolWorker {
+ public:
+  explicit CmdSlowWorker(CmdThreadPool *pool, int onceTask, std::string name)
+      : CmdWorkThreadPoolWorker(pool, onceTask, std::move(name)) {}
+
+  // when the slow worker queue is empty, it will try to get the fast worker
+  void LoadWork() override;
+
+ private:
+  bool loopMore = false;
+  int waitTime = 200;
+};
+
+}  // namespace pikiwidb

--- a/src/cmd_thread_pool_worker.h
+++ b/src/cmd_thread_pool_worker.h
@@ -60,8 +60,8 @@ class CmdSlowWorker : public CmdWorkThreadPoolWorker {
   void LoadWork() override;
 
  private:
-  bool loopMore_ = false;
-  int waitTime_ = 200;
+  bool loopMore_ = false;  // When the slow queue is empty, try to get the fast queue
+  int waitTime_ = 200;     // When the slow queue is empty, wait 200 ms to check again
 };
 
 }  // namespace pikiwidb

--- a/src/cmd_thread_pool_worker.h
+++ b/src/cmd_thread_pool_worker.h
@@ -22,7 +22,9 @@ class CmdWorkThreadPoolWorker {
     cmd_table_manager_.InitCmdTable();
   }
 
-  void Work(const std::stop_token &stopToken);
+  void Work();
+
+  void Stop();
 
   // load the task from the thread pool
   virtual void LoadWork() = 0;
@@ -34,6 +36,7 @@ class CmdWorkThreadPoolWorker {
   CmdThreadPool *pool_;
   const int onceTask_ = 0;  // the max task num that the worker can get from the thread pool
   const std::string name_;
+  bool running_ = true;
 
   pikiwidb::CmdTableManager cmd_table_manager_;
 };

--- a/src/config.cc
+++ b/src/config.cc
@@ -172,6 +172,8 @@ bool LoadPikiwiDBConfig(const char* cfgFile, PConfig& cfg) {
 
   // slave threads
   cfg.slave_threads_num = parser.GetData<int>("slave-threads", 1);
+  cfg.fast_cmd_threads_num = parser.GetData<int>("fast-threads", 1);
+  cfg.slow_cmd_threads_num = parser.GetData<int>("slow-threads", 1);
 
   // backend
   cfg.backend = parser.GetData<int>("backend", kBackEndNone);
@@ -202,6 +204,8 @@ bool PConfig::CheckArgs() const {
   RETURN_IF_FAIL(maxmemory >= 512 * 1024 * 1024UL);
   RETURN_IF_FAIL(maxmemorySamples > 0 && maxmemorySamples < 10);
   RETURN_IF_FAIL(worker_threads_num > 0 && worker_threads_num < 129);  // as redis
+  RETURN_IF_FAIL(fast_cmd_threads_num > 0 && fast_cmd_threads_num < 16);
+  RETURN_IF_FAIL(slow_cmd_threads_num > 0 && slow_cmd_threads_num < 16);
   RETURN_IF_FAIL(backend >= kBackEndNone && backend < kBackEndMax);
   RETURN_IF_FAIL(backendHz >= 1 && backendHz <= 50);
   RETURN_IF_FAIL(db_instance_num >= 1);

--- a/src/config.h
+++ b/src/config.h
@@ -78,6 +78,9 @@ struct PConfig {
   // THREADED SLAVE
   int slave_threads_num;
 
+  int fast_cmd_threads_num;
+  int slow_cmd_threads_num;
+
   int backend;  // enum BackEndType
   PString backendPath;
   int backendHz;  // the frequency of dump to backend

--- a/src/io_thread_pool.cc
+++ b/src/io_thread_pool.cc
@@ -198,7 +198,7 @@ void WorkIOThreadPool::StartWorkers() {
         }
         auto client = writeQueue_[index].front();
         if (client->State() == ClientState::kOK) {
-          client->WriteReply2Net();
+          client->WriteReply2Client();
         }
         writeQueue_[index].pop_front();
       }

--- a/src/io_thread_pool.cc
+++ b/src/io_thread_pool.cc
@@ -197,9 +197,12 @@ void WorkIOThreadPool::StartWorkers() {
         std::unique_lock lock(*writeMutex_[index]);
         while (writeQueue_[index].empty()) {
           if (!writeRunning_) {
-            goto END;
+            break;
           }
           writeCond_[index]->wait(lock);
+        }
+        if (!writeRunning_) {
+          break;
         }
         auto client = writeQueue_[index].front();
         if (client->State() == ClientState::kOK) {
@@ -207,7 +210,6 @@ void WorkIOThreadPool::StartWorkers() {
         }
         writeQueue_[index].pop_front();
       }
-    END:
       INFO("worker write thread {}, goodbye...", index);
     });
 

--- a/src/io_thread_pool.h
+++ b/src/io_thread_pool.h
@@ -98,6 +98,7 @@ class WorkIOThreadPool : public IOThreadPool {
  private:
   void StartWorkers() override;
 
+ private:
   std::vector<std::thread> writeThreads_;
   std::vector<std::unique_ptr<std::mutex>> writeMutex_;
   std::vector<std::unique_ptr<std::condition_variable>> writeCond_;

--- a/src/io_thread_pool.h
+++ b/src/io_thread_pool.h
@@ -75,7 +75,7 @@ class IOThreadPool {
   EventLoop base_;
 
   std::atomic<size_t> worker_num_{0};
-  std::vector<std::jthread> worker_threads_;
+  std::vector<std::thread> worker_threads_;
   std::vector<std::unique_ptr<EventLoop>> worker_loops_;
   mutable std::atomic<size_t> current_worker_loop_{0};
 
@@ -98,11 +98,12 @@ class WorkIOThreadPool : public IOThreadPool {
  private:
   void StartWorkers() override;
 
-  std::vector<std::jthread> writeThreads_;
+  std::vector<std::thread> writeThreads_;
   std::vector<std::unique_ptr<std::mutex>> writeMutex_;
   std::vector<std::unique_ptr<std::condition_variable>> writeCond_;
   std::vector<std::deque<std::shared_ptr<PClient>>> writeQueue_;
   std::atomic<uint64_t> counter_ = 0;
+  bool writeRunning_ = true;
 };
 
 }  // namespace pikiwidb

--- a/src/net/http_client.cc
+++ b/src/net/http_client.cc
@@ -10,7 +10,7 @@ HttpClient::HttpClient() : parser_(HTTP_RESPONSE) {}
 void HttpClient::OnConnect(TcpConnection* conn) {
   assert(loop_ == conn->GetEventLoop());
 
-  INFO("HttpClient::OnConnect to {}:{} in loop {}", conn->GetPeerIp(), conn->GetPeerPort(), loop_->GetName());
+  INFO("HttpClient::OnConnect to {}:{} in loop {}", conn->GetPeerIP(), conn->GetPeerPort(), loop_->GetName());
   never_connected_ = false;
 
   conn_ = std::static_pointer_cast<TcpConnection>(conn->shared_from_this());

--- a/src/net/tcp_connection.h
+++ b/src/net/tcp_connection.h
@@ -56,7 +56,7 @@ class TcpConnection : public EventObject {
   void ResetEventLoop(EventLoop* new_loop);
   EventLoop* SelectSlaveEventLoop();
   EventLoop* GetEventLoop() const { return loop_; }
-  const std::string& GetPeerIp() const { return peer_ip_; }
+  const std::string& GetPeerIP() const { return peer_ip_; }
   int GetPeerPort() const { return peer_port_; }
   const sockaddr_in& PeerAddr() const { return peer_addr_; }
 

--- a/src/pikiwidb.cc
+++ b/src/pikiwidb.cc
@@ -174,7 +174,10 @@ void PikiwiDB::OnNewConnection(pikiwidb::TcpConnection* obj) {
   auto msg_cb = std::bind(&pikiwidb::PClient::HandlePackets, client.get(), std::placeholders::_1, std::placeholders::_2,
                           std::placeholders::_3);
   obj->SetMessageCallback(msg_cb);
-  obj->SetOnDisconnect([](pikiwidb::TcpConnection* obj) { INFO("disconnect from {}", obj->GetPeerIp()); });
+  obj->SetOnDisconnect([](pikiwidb::TcpConnection* obj) {
+    INFO("disconnect from {}", obj->GetPeerIp());
+    obj->GetContext<pikiwidb::PClient>()->SetState(pikiwidb::ClientState::kClosed);
+  });
   obj->SetNodelay(true);
   obj->SetEventLoopSelector([this]() { return worker_threads_.ChooseNextWorkerEventLoop(); });
   obj->SetSlaveEventLoopSelector([this]() { return slave_threads_.ChooseNextWorkerEventLoop(); });
@@ -214,6 +217,13 @@ bool PikiwiDB::Init() {
   worker_threads_.SetWorkerNum(static_cast<size_t>(g_config.worker_threads_num));
   slave_threads_.SetWorkerNum(static_cast<size_t>(g_config.slave_threads_num));
 
+  // now we only use fast cmd thread pool
+  auto status = cmd_threads_.Init(g_config.fast_cmd_threads_num, 0, "pikiwidb-cmd");
+  if (!status.ok()) {
+    ERROR("init cmd thread pool failed: {}", status.ToString());
+    return false;
+  }
+
   PSTORE.Init(g_config.databases);
 
   // Only if there is no backend, load rdb
@@ -234,7 +244,7 @@ bool PikiwiDB::Init() {
     PREPL.SetMasterAddr(g_config.masterIp.c_str(), g_config.masterPort);
   }
 
-  cmd_table_manager_.InitCmdTable();
+  //  cmd_table_manager_.InitCmdTable();
 
   return true;
 }
@@ -243,7 +253,9 @@ void PikiwiDB::Run() {
   worker_threads_.SetName("pikiwi-main");
   slave_threads_.SetName("pikiwi-slave");
 
-  std::thread t([this]() {
+  cmd_threads_.Start();
+
+  std::jthread t([this]() {
     auto slave_loop = slave_threads_.BaseLoop();
     slave_loop->Init();
     slave_threads_.Run(0, nullptr);
@@ -251,7 +263,7 @@ void PikiwiDB::Run() {
 
   worker_threads_.Run(0, nullptr);
 
-  t.join();  // wait for slave thread exit
+  //  t.join();  // wait for slave thread exit
   INFO("server exit running");
 }
 
@@ -260,7 +272,7 @@ void PikiwiDB::Stop() {
   worker_threads_.Exit();
 }
 
-pikiwidb::CmdTableManager& PikiwiDB::GetCmdTableManager() { return cmd_table_manager_; }
+// pikiwidb::CmdTableManager& PikiwiDB::GetCmdTableManager() { return cmd_table_manager_; }
 
 static void InitLogs() {
   logger::Init("logs/pikiwidb_server.log");

--- a/src/pikiwidb.cc
+++ b/src/pikiwidb.cc
@@ -255,7 +255,7 @@ void PikiwiDB::Run() {
 
   cmd_threads_.Start();
 
-  std::jthread t([this]() {
+  std::thread t([this]() {
     auto slave_loop = slave_threads_.BaseLoop();
     slave_loop->Init();
     slave_threads_.Run(0, nullptr);
@@ -263,13 +263,16 @@ void PikiwiDB::Run() {
 
   worker_threads_.Run(0, nullptr);
 
-  //  t.join();  // wait for slave thread exit
+  if (t.joinable()) {
+    t.join();  // wait for slave thread exit
+  }
   INFO("server exit running");
 }
 
 void PikiwiDB::Stop() {
   slave_threads_.Exit();
   worker_threads_.Exit();
+  cmd_threads_.Stop();
 }
 
 // pikiwidb::CmdTableManager& PikiwiDB::GetCmdTableManager() { return cmd_table_manager_; }

--- a/src/pikiwidb.cc
+++ b/src/pikiwidb.cc
@@ -164,7 +164,7 @@ static void LoadDBFromDisk() {
 }
 
 void PikiwiDB::OnNewConnection(pikiwidb::TcpConnection* obj) {
-  INFO("New connection from {}:{}", obj->GetPeerIp(), obj->GetPeerPort());
+  INFO("New connection from {}:{}", obj->GetPeerIP(), obj->GetPeerPort());
 
   auto client = std::make_shared<pikiwidb::PClient>(obj);
   obj->SetContext(client);
@@ -175,7 +175,7 @@ void PikiwiDB::OnNewConnection(pikiwidb::TcpConnection* obj) {
                           std::placeholders::_3);
   obj->SetMessageCallback(msg_cb);
   obj->SetOnDisconnect([](pikiwidb::TcpConnection* obj) {
-    INFO("disconnect from {}", obj->GetPeerIp());
+    INFO("disconnect from {}", obj->GetPeerIP());
     obj->GetContext<pikiwidb::PClient>()->SetState(pikiwidb::ClientState::kClosed);
   });
   obj->SetNodelay(true);

--- a/src/pikiwidb.h
+++ b/src/pikiwidb.h
@@ -30,7 +30,7 @@ class PikiwiDB final {
   void OnNewConnection(pikiwidb::TcpConnection* obj);
 
   //  pikiwidb::CmdTableManager& GetCmdTableManager();
-  uint32_t GetCmdId() { return ++cmdId_; };
+  uint32_t GetCmdID() { return ++cmdId_; };
 
   void SubmitFast(const std::shared_ptr<pikiwidb::CmdThreadPoolTask>& runner) { cmd_threads_.SubmitFast(runner); }
 

--- a/src/pikiwidb.h
+++ b/src/pikiwidb.h
@@ -30,7 +30,7 @@ class PikiwiDB final {
   void OnNewConnection(pikiwidb::TcpConnection* obj);
 
   //  pikiwidb::CmdTableManager& GetCmdTableManager();
-  uint32_t GetCmdID() { return ++cmdId_; };
+  uint32_t GetCmdID() { return ++cmd_id_; };
 
   void SubmitFast(const std::shared_ptr<pikiwidb::CmdThreadPoolTask>& runner) { cmd_threads_.SubmitFast(runner); }
 
@@ -52,7 +52,7 @@ class PikiwiDB final {
   pikiwidb::CmdThreadPool cmd_threads_;
   //  pikiwidb::CmdTableManager cmd_table_manager_;
 
-  uint32_t cmdId_ = 0;
+  uint32_t cmd_id_ = 0;
 };
 
 extern std::unique_ptr<PikiwiDB> g_pikiwidb;

--- a/src/pikiwidb.h
+++ b/src/pikiwidb.h
@@ -6,6 +6,7 @@
  */
 
 #include "cmd_table_manager.h"
+#include "cmd_thread_pool.h"
 #include "common.h"
 #include "event_loop.h"
 #include "io_thread_pool.h"
@@ -28,7 +29,12 @@ class PikiwiDB final {
 
   void OnNewConnection(pikiwidb::TcpConnection* obj);
 
-  pikiwidb::CmdTableManager& GetCmdTableManager();
+  //  pikiwidb::CmdTableManager& GetCmdTableManager();
+  uint32_t GetCmdId() { return ++cmdId_; };
+
+  void SubmitFast(const std::shared_ptr<pikiwidb::CmdThreadPoolTask>& runner) { cmd_threads_.SubmitFast(runner); }
+
+  void PushWriteTask(const std::shared_ptr<pikiwidb::PClient>& client) { worker_threads_.PushWriteTask(client); }
 
  public:
   PString cfg_file_;
@@ -41,9 +47,12 @@ class PikiwiDB final {
   static const uint32_t kRunidSize;
 
  private:
-  pikiwidb::IOThreadPool worker_threads_;
+  pikiwidb::WorkIOThreadPool worker_threads_;
   pikiwidb::IOThreadPool slave_threads_;
-  pikiwidb::CmdTableManager cmd_table_manager_;
+  pikiwidb::CmdThreadPool cmd_threads_;
+  //  pikiwidb::CmdTableManager cmd_table_manager_;
+
+  uint32_t cmdId_ = 0;
 };
 
 extern std::unique_ptr<PikiwiDB> g_pikiwidb;


### PR DESCRIPTION
fix issue https://github.com/OpenAtomFoundation/pikiwidb/issues/100

加了网络的读写分离,和命令在线程池中执行

这个pr只有 线程池和读写分离功能

后续 还有两个功能, 待开发

- 对象复用池 类似 go中的 `sync.pool`
- 移除 `libevent` 依赖, 使用 最早的 网络库

`cmd_thread_pool` 是命令的线程池, 目前支持了快慢命令分离, 但是因现在命令中没有加对应的flag,就暂时全都按照快命令执行了

这是目前我想到的问题

- 写线程
在写命令线程中, 现在写命令的线程数量和读线程是一致的, 1:1的关系. 但是没有做到读写线程的绑定,
比如: 一个命令A 是 `get a`, 这个命令的读线程是线程 **R1**, 这个线程是 client在连接网络时就确定了. 当这个命令在线程池中执行完成后,会发到写线程中, 这时候, 会轮训 所有写线程, 找到一个写线程, 然后执行写入网络的操作. 可能这次放到 **w2** 中, 下次会放到 **W3**  中, 这段代码体现在 `WorkIOThreadPool::PushWriteTask` 这个函数中

------

- 命令线程池

现在的命令线程池中, 所有线程公用了一把锁, 可能会比较重, 如果这部分是瓶颈, 可以和 IO的写线程中那样, 每个写线程 一个独立的队列,然后通过轮训或者别的策略, 向线程池中每个线程的队列加任务,

现在的命令线程池中, 如果慢命令队列是空闲的, 会尝试从 读线程池中偷取 快命令来执行

这段逻辑在

```cpp
void CmdSlowWorker::LoadWork() {
  {
    std::unique_lock lock(pool_->slowMutex_);
    while (pool_->slowTasks_.empty() && loopMore) {  // loopMore is used to get the fast worker, 定时唤醒去快命令队列中找任务
      pool_->slowCondition_.wait_for(lock, std::chrono::milliseconds(waitTime));
      loopMore = false;
    }

    const auto num = std::min(static_cast<int>(pool_->slowTasks_.size()), onceTask_);
    std::move(pool_->slowTasks_.begin(), pool_->slowTasks_.begin() + num, std::back_inserter(selfTask));
    pool_->slowTasks_.erase(pool_->slowTasks_.begin(), pool_->slowTasks_.begin() + num);
  }
```

----

- 命令对象

现在还没做对象缓存池, 现在用的做法是 在命令线程池中, 每个线程单独维护一个 cmdTable, 来做命令的隔离

后面设想的是,在读线程中, 解析出 本次命令的参数, 根据第一个参数区分这个命令是 **快** / **慢** 命令, 并把所有参数 包装成一个 **task** 放到对应的线程池中. 在对应的线程池中, 获取这个执行这个命令的对象, 然后执行对应的命令

这样做的考虑是, 在 读线程中就确定命令,并且获取命令的对象, 这样就能做到在向 命令线程池中添加任务时就知道, 当前命令时快命令还是慢命令, 这样就能比较好的做到快慢分离了

**每个线程单独维护一个 cmdTable** 这个逻辑在
```cpp
class CmdWorkThreadPoolWorker {
 public:
  explicit CmdWorkThreadPoolWorker(CmdThreadPool *pool, int onceTask, std::string name)
      : pool_(pool), onceTask_(onceTask), name_(std::move(name)) {
    cmd_table_manager_.InitCmdTable();
  }
```