### PR TITLE
fix:add class DB & sharedmutex

### DIFF
--- a/src/base_cmd.cc
+++ b/src/base_cmd.cc
@@ -11,6 +11,7 @@
 
 namespace pikiwidb {
 
+
 BaseCmd::BaseCmd(std::string name, int16_t arity, uint32_t flag, uint32_t aclCategory) {
   name_ = std::move(name);
   arity_ = arity;
@@ -29,6 +30,12 @@ bool BaseCmd::CheckArg(size_t num) const {
 std::vector<std::string> BaseCmd::CurrentKey(PClient* client) const { return std::vector<std::string>{client->Key()}; }
 
 void BaseCmd::Execute(PClient* client) {
+  if (static_cast<bool>(flag_ & kCmdFlagsSuspend)) {
+    std::lock_guard lock(PSTORE.GetBackend(client->GetCurrentDB())->GetSharedMutex());
+  } else {
+    std::shared_lock sharedlock(PSTORE.GetBackend(client->GetCurrentDB())->GetSharedMutex());
+  }
+
   if (!DoInitial(client)) {
     return;
   }

--- a/src/base_cmd.cc
+++ b/src/base_cmd.cc
@@ -30,9 +30,7 @@ std::vector<std::string> BaseCmd::CurrentKey(PClient* client) const { return std
 
 void BaseCmd::Execute(PClient* client) {
   auto dbNum = client->GetCurrentDB();
-  if (static_cast<bool>(flag_ & kCmdFlagsSuspend)) {
-    PSTORE.GetBackend(dbNum)->Lock();
-  } else {
+  if (!static_cast<bool>(flag_ & kCmdFlagsSuspend)) {
     PSTORE.GetBackend(dbNum)->LockShared();
   }
 
@@ -41,9 +39,7 @@ void BaseCmd::Execute(PClient* client) {
   }
   DoCmd(client);
 
-  if (static_cast<bool>(flag_ & kCmdFlagsSuspend)) {
-    PSTORE.GetBackend(dbNum)->UnLock();
-  } else {
+  if (!static_cast<bool>(flag_ & kCmdFlagsSuspend)) {
     PSTORE.GetBackend(dbNum)->UnLockShared();
   }
 }

--- a/src/base_cmd.cc
+++ b/src/base_cmd.cc
@@ -29,9 +29,9 @@ bool BaseCmd::CheckArg(size_t num) const {
 std::vector<std::string> BaseCmd::CurrentKey(PClient* client) const { return std::vector<std::string>{client->Key()}; }
 
 void BaseCmd::Execute(PClient* client) {
-  auto dbNum = client->GetCurrentDB();
-  if (!static_cast<bool>(flag_ & kCmdFlagsSuspend)) {
-    PSTORE.GetBackend(dbNum)->LockShared();
+  auto dbIndex = client->GetCurrentDB();
+  if (!isExclusive()) {
+    PSTORE.GetBackend(dbIndex)->LockShared();
   }
 
   if (!DoInitial(client)) {
@@ -39,8 +39,8 @@ void BaseCmd::Execute(PClient* client) {
   }
   DoCmd(client);
 
-  if (!static_cast<bool>(flag_ & kCmdFlagsSuspend)) {
-    PSTORE.GetBackend(dbNum)->UnLockShared();
+  if (!isExclusive()) {
+    PSTORE.GetBackend(dbIndex)->UnLockShared();
   }
 }
 

--- a/src/base_cmd.cc
+++ b/src/base_cmd.cc
@@ -29,10 +29,11 @@ bool BaseCmd::CheckArg(size_t num) const {
 std::vector<std::string> BaseCmd::CurrentKey(PClient* client) const { return std::vector<std::string>{client->Key()}; }
 
 void BaseCmd::Execute(PClient* client) {
+  auto dbNum = client->GetCurrentDB();
   if (static_cast<bool>(flag_ & kCmdFlagsSuspend)) {
-    PSTORE.GetBackend(client->GetCurrentDB())->Lock();
+    PSTORE.GetBackend(dbNum)->Lock();
   } else {
-    PSTORE.GetBackend(client->GetCurrentDB())->LockShared();
+    PSTORE.GetBackend(dbNum)->LockShared();
   }
 
   if (!DoInitial(client)) {
@@ -41,9 +42,9 @@ void BaseCmd::Execute(PClient* client) {
   DoCmd(client);
 
   if (static_cast<bool>(flag_ & kCmdFlagsSuspend)) {
-    PSTORE.GetBackend(client->GetCurrentDB())->UnLock();
+    PSTORE.GetBackend(dbNum)->UnLock();
   } else {
-    PSTORE.GetBackend(client->GetCurrentDB())->UnLockShared();
+    PSTORE.GetBackend(dbNum)->UnLockShared();
   }
 }
 

--- a/src/base_cmd.h
+++ b/src/base_cmd.h
@@ -138,7 +138,7 @@ enum CmdFlags {
   kCmdFlagsProtected = (1 << 12),        // Don't accept in scripts
   kCmdFlagsModuleNoCluster = (1 << 13),  // No cluster mode support
   kCmdFlagsNoMulti = (1 << 14),          // Cannot be pipelined
-  kCmdFlagsSuspend = (1 << 15),          // May change Storage pointer
+  kCmdFlagsExclusive = (1 << 15),        // May change Storage pointer, like pika's kCmdFlagsSuspend
 };
 
 enum AclCategory {
@@ -273,6 +273,8 @@ class BaseCmd : public std::enable_shared_from_this<BaseCmd> {
   //  std::shared_ptr<std::string> GetResp();
 
   uint32_t GetCmdId() const;
+
+  bool isExclusive() { return static_cast<bool>(flag_ & kCmdFlagsExclusive); }
 
  protected:
   // Execute a specific command

--- a/src/base_cmd.h
+++ b/src/base_cmd.h
@@ -16,6 +16,7 @@
 #include <vector>
 
 #include "client.h"
+#include "store.h"
 
 namespace pikiwidb {
 
@@ -137,6 +138,7 @@ enum CmdFlags {
   kCmdFlagsProtected = (1 << 12),        // Don't accept in scripts
   kCmdFlagsModuleNoCluster = (1 << 13),  // No cluster mode support
   kCmdFlagsNoMulti = (1 << 14),          // Cannot be pipelined
+  kCmdFlagsSuspend = (1 << 15),          // May change Storage pointer
 };
 
 enum AclCategory {

--- a/src/cmd_hash.cc
+++ b/src/cmd_hash.cc
@@ -37,7 +37,7 @@ void HSetCmd::DoCmd(PClient* client) {
     auto value = client->argv_[i + 1];
     int32_t temp = 0;
     // TODO(century): current bw doesn't support multiple fvs, fix it when necessary
-    s = PSTORE.GetBackend(client->GetCurrentDB())->HSet(client->Key(), field, value, &temp);
+    s = PSTORE.GetBackend(client->GetCurrentDB())->GetStorage()->HSet(client->Key(), field, value, &temp);
     if (s.ok()) {
       ret += temp;
     } else {
@@ -82,7 +82,7 @@ bool HDelCmd::DoInitial(PClient* client) {
 void HDelCmd::DoCmd(PClient* client) {
   int32_t res{};
   std::vector<std::string> fields(client->argv_.begin() + 2, client->argv_.end());
-  auto s = PSTORE.GetBackend(client->GetCurrentDB())->HDel(client->Key(), fields, &res);
+  auto s = PSTORE.GetBackend(client->GetCurrentDB())->GetStorage()->HDel(client->Key(), fields, &res);
   if (!s.ok() && !s.IsNotFound()) {
     client->SetRes(CmdRes::kErrOther, s.ToString());
     return;
@@ -125,7 +125,7 @@ bool HMGetCmd::DoInitial(PClient* client) {
 
 void HMGetCmd::DoCmd(PClient* client) {
   std::vector<storage::ValueStatus> vss;
-  auto s = PSTORE.GetBackend(client->GetCurrentDB())->HMGet(client->Key(), client->Fields(), &vss);
+  auto s = PSTORE.GetBackend(client->GetCurrentDB())->GetStorage()->HMGet(client->Key(), client->Fields(), &vss);
   if (s.ok() || s.IsNotFound()) {
     client->AppendArrayLenUint64(vss.size());
     for (size_t i = 0; i < vss.size(); ++i) {
@@ -160,6 +160,7 @@ void HGetAllCmd::DoCmd(PClient* client) {
   do {
     fvs.clear();
     s = PSTORE.GetBackend(client->GetCurrentDB())
+            ->GetStorage()
             ->HScan(client->Key(), cursor, "*", PIKIWIDB_SCAN_STEP_LENGTH, &fvs, &next_cursor);
     if (!s.ok()) {
       raw.clear();
@@ -199,7 +200,7 @@ bool HKeysCmd::DoInitial(PClient* client) {
 
 void HKeysCmd::DoCmd(PClient* client) {
   std::vector<std::string> fields;
-  auto s = PSTORE.GetBackend(client->GetCurrentDB())->HKeys(client->Key(), &fields);
+  auto s = PSTORE.GetBackend(client->GetCurrentDB())->GetStorage()->HKeys(client->Key(), &fields);
   if (s.ok() || s.IsNotFound()) {
     client->AppendArrayLenUint64(fields.size());
     for (const auto& field : fields) {
@@ -223,7 +224,7 @@ bool HLenCmd::DoInitial(PClient* client) {
 
 void HLenCmd::DoCmd(PClient* client) {
   int32_t len = 0;
-  auto s = PSTORE.GetBackend(client->GetCurrentDB())->HLen(client->Key(), &len);
+  auto s = PSTORE.GetBackend(client->GetCurrentDB())->GetStorage()->HLen(client->Key(), &len);
   if (s.ok() || s.IsNotFound()) {
     client->AppendInteger(len);
   } else {
@@ -241,7 +242,7 @@ bool HStrLenCmd::DoInitial(PClient* client) {
 
 void HStrLenCmd::DoCmd(PClient* client) {
   int32_t len = 0;
-  auto s = PSTORE.GetBackend(client->GetCurrentDB())->HStrlen(client->Key(), client->argv_[2], &len);
+  auto s = PSTORE.GetBackend(client->GetCurrentDB())->GetStorage()->HStrlen(client->Key(), client->argv_[2], &len);
   if (s.ok() || s.IsNotFound()) {
     client->AppendInteger(len);
   } else {
@@ -288,8 +289,9 @@ void HScanCmd::DoCmd(PClient* client) {
   // execute command
   std::vector<storage::FieldValue> fvs;
   int64_t next_cursor{};
-  auto status =
-      PSTORE.GetBackend(client->GetCurrentDB())->HScan(client->Key(), cursor, pattern, count, &fvs, &next_cursor);
+  auto status = PSTORE.GetBackend(client->GetCurrentDB())
+                    ->GetStorage()
+                    ->HScan(client->Key(), cursor, pattern, count, &fvs, &next_cursor);
   if (!status.ok() && !status.IsNotFound()) {
     client->SetRes(CmdRes::kErrOther, status.ToString());
     return;
@@ -344,6 +346,7 @@ void HIncrbyFloatCmd::DoCmd(PClient* client) {
   }
   std::string newValue;
   storage::Status s = PSTORE.GetBackend(client->GetCurrentDB())
+                          ->GetStorage()
                           ->HIncrbyfloat(client->Key(), client->argv_[2], client->argv_[3], &newValue);
   if (s.ok() || s.IsNotFound()) {
     client->AppendString(newValue);
@@ -363,7 +366,9 @@ bool HSetNXCmd::DoInitial(PClient* client) {
 void HSetNXCmd::DoCmd(PClient* client) {
   int32_t temp = 0;
   storage::Status s;
-  s = PSTORE.GetBackend(client->GetCurrentDB())->HSetnx(client->Key(), client->argv_[2], client->argv_[3], &temp);
+  s = PSTORE.GetBackend(client->GetCurrentDB())
+          ->GetStorage()
+          ->HSetnx(client->Key(), client->argv_[2], client->argv_[3], &temp);
   if (s.ok()) {
     client->AppendInteger(temp);
   } else {
@@ -389,7 +394,7 @@ void HIncrbyCmd::DoCmd(PClient* client) {
 
   int64_t temp = 0;
   storage::Status s =
-      PSTORE.GetBackend(client->GetCurrentDB())->HIncrby(client->Key(), client->argv_[2], int_by, &temp);
+      PSTORE.GetBackend(client->GetCurrentDB())->GetStorage()->HIncrby(client->Key(), client->argv_[2], int_by, &temp);
   if (s.ok() || s.IsNotFound()) {
     client->AppendInteger(temp);
   } else {
@@ -431,7 +436,7 @@ void HRandFieldCmd::DoCmd(PClient* client) {
 
   // execute command
   std::vector<std::string> res;
-  auto s = PSTORE.GetBackend(client->GetCurrentDB())->HRandField(client->Key(), count, with_values, &res);
+  auto s = PSTORE.GetBackend(client->GetCurrentDB())->GetStorage()->HRandField(client->Key(), count, with_values, &res);
   if (s.IsNotFound()) {
     client->AppendString("");
     return;

--- a/src/cmd_hash.cc
+++ b/src/cmd_hash.cc
@@ -61,7 +61,7 @@ bool HGetCmd::DoInitial(PClient* client) {
 void HGetCmd::DoCmd(PClient* client) {
   PString value;
   auto field = client->argv_[2];
-  storage::Status s = PSTORE.GetBackend(client->GetCurrentDB())->HGet(client->Key(), field, &value);
+  storage::Status s = PSTORE.GetBackend(client->GetCurrentDB())->GetStorage()->HGet(client->Key(), field, &value);
   if (s.ok()) {
     client->AppendString(value);
   } else if (s.IsNotFound()) {
@@ -104,7 +104,7 @@ bool HMSetCmd::DoInitial(PClient* client) {
 }
 
 void HMSetCmd::DoCmd(PClient* client) {
-  storage::Status s = PSTORE.GetBackend(client->GetCurrentDB())->HMSet(client->Key(), client->Fvs());
+  storage::Status s = PSTORE.GetBackend(client->GetCurrentDB())->GetStorage()->HMSet(client->Key(), client->Fvs());
   if (s.ok()) {
     client->SetRes(CmdRes::kOK);
   } else {
@@ -315,7 +315,7 @@ bool HValsCmd::DoInitial(PClient* client) {
 
 void HValsCmd::DoCmd(PClient* client) {
   std::vector<std::string> valueVec;
-  storage::Status s = PSTORE.GetBackend(client->GetCurrentDB())->HVals(client->Key(), &valueVec);
+  storage::Status s = PSTORE.GetBackend(client->GetCurrentDB())->GetStorage()->HVals(client->Key(), &valueVec);
   if (s.ok() || s.IsNotFound()) {
     client->AppendStringVector(valueVec);
   } else {

--- a/src/cmd_keys.cc
+++ b/src/cmd_keys.cc
@@ -23,7 +23,7 @@ bool DelCmd::DoInitial(PClient* client) {
 }
 
 void DelCmd::DoCmd(PClient* client) {
-  int64_t count = PSTORE.GetBackend(client->GetCurrentDB())->Del(client->Keys());
+  int64_t count = PSTORE.GetBackend(client->GetCurrentDB())->GetStorage()->Del(client->Keys());
   if (count >= 0) {
     client->AppendInteger(count);
   } else {
@@ -41,7 +41,7 @@ bool ExistsCmd::DoInitial(PClient* client) {
 }
 
 void ExistsCmd::DoCmd(PClient* client) {
-  int64_t count = PSTORE.GetBackend(client->GetCurrentDB())->Exists(client->Keys());
+  int64_t count = PSTORE.GetBackend(client->GetCurrentDB())->GetStorage()->Exists(client->Keys());
   if (count >= 0) {
     client->AppendInteger(count);
     //    if (PSTORE.ExistsKey(client->Key())) {
@@ -68,7 +68,7 @@ void PExpireCmd::DoCmd(PClient* client) {
     client->SetRes(CmdRes ::kInvalidInt);
     return;
   }
-  auto res = PSTORE.GetBackend(client->GetCurrentDB())->Expire(client->Key(), msec / 1000);
+  auto res = PSTORE.GetBackend(client->GetCurrentDB())->GetStorage()->Expire(client->Key(), msec / 1000);
   if (res != -1) {
     client->AppendInteger(res);
   } else {
@@ -90,7 +90,7 @@ void ExpireatCmd::DoCmd(PClient* client) {
     client->SetRes(CmdRes ::kInvalidInt);
     return;
   }
-  auto res = PSTORE.GetBackend(client->GetCurrentDB())->Expireat(client->Key(), time_stamp);
+  auto res = PSTORE.GetBackend(client->GetCurrentDB())->GetStorage()->Expireat(client->Key(), time_stamp);
   if (res != -1) {
     client->AppendInteger(res);
   } else {
@@ -113,7 +113,7 @@ void PExpireatCmd::DoCmd(PClient* client) {
     client->SetRes(CmdRes ::kInvalidInt);
     return;
   }
-  auto res = PSTORE.GetBackend(client->GetCurrentDB())->Expireat(client->Key(), time_stamp_ms / 1000);
+  auto res = PSTORE.GetBackend(client->GetCurrentDB())->GetStorage()->Expireat(client->Key(), time_stamp_ms / 1000);
   if (res != -1) {
     client->AppendInteger(res);
   } else {
@@ -131,7 +131,7 @@ bool PersistCmd::DoInitial(PClient* client) {
 
 void PersistCmd::DoCmd(PClient* client) {
   std::map<storage::DataType, storage::Status> type_status;
-  auto res = PSTORE.GetBackend(client->GetCurrentDB())->Persist(client->Key(), &type_status);
+  auto res = PSTORE.GetBackend(client->GetCurrentDB())->GetStorage()->Persist(client->Key(), &type_status);
   if (res != -1) {
     client->AppendInteger(res);
   } else {

--- a/src/cmd_kv.cc
+++ b/src/cmd_kv.cc
@@ -24,7 +24,7 @@ bool GetCmd::DoInitial(PClient* client) {
 void GetCmd::DoCmd(PClient* client) {
   PString value;
   uint64_t ttl = -1;
-  storage::Status s = PSTORE.GetBackend(client->GetCurrentDB())->GetWithTTL(client->Key(), &value, &ttl);
+  storage::Status s = PSTORE.GetBackend(client->GetCurrentDB())->GetStorage()->GetWithTTL(client->Key(), &value, &ttl);
   if (s.ok()) {
     client->AppendString(value);
   } else if (s.IsNotFound()) {
@@ -43,7 +43,7 @@ bool SetCmd::DoInitial(PClient* client) {
 }
 
 void SetCmd::DoCmd(PClient* client) {
-  storage::Status s = PSTORE.GetBackend(client->GetCurrentDB())->Set(client->Key(), client->argv_[2]);
+  storage::Status s = PSTORE.GetBackend(client->GetCurrentDB())->GetStorage()->Set(client->Key(), client->argv_[2]);
   if (s.ok()) {
     client->SetRes(CmdRes::kOK);
   } else {
@@ -61,7 +61,7 @@ bool AppendCmd::DoInitial(PClient* client) {
 
 void AppendCmd::DoCmd(PClient* client) {
   int32_t new_len = 0;
-  storage::Status s = PSTORE.GetBackend(client->GetCurrentDB())->Append(client->Key(), client->argv_[2], &new_len);
+  storage::Status s = PSTORE.GetBackend(client->GetCurrentDB())->GetStorage()->Append(client->Key(), client->argv_[2], &new_len);
   if (s.ok() || s.IsNotFound()) {
     client->AppendInteger(new_len);
   } else {
@@ -79,7 +79,7 @@ bool GetSetCmd::DoInitial(PClient* client) {
 
 void GetSetCmd::DoCmd(PClient* client) {
   std::string old_value;
-  storage::Status s = PSTORE.GetBackend(client->GetCurrentDB())->GetSet(client->Key(), client->argv_[2], &old_value);
+  storage::Status s = PSTORE.GetBackend(client->GetCurrentDB())->GetStorage()->GetSet(client->Key(), client->argv_[2], &old_value);
   if (s.ok()) {
     if (old_value.empty()) {
       client->AppendContent("$-1");
@@ -104,7 +104,7 @@ bool MGetCmd::DoInitial(PClient* client) {
 
 void MGetCmd::DoCmd(PClient* client) {
   std::vector<storage::ValueStatus> db_value_status_array;
-  storage::Status s = PSTORE.GetBackend(client->GetCurrentDB())->MGet(client->Keys(), &db_value_status_array);
+  storage::Status s = PSTORE.GetBackend(client->GetCurrentDB())->GetStorage()->MGet(client->Keys(), &db_value_status_array);
   if (s.ok()) {
     client->AppendArrayLen(db_value_status_array.size());
     for (const auto& vs : db_value_status_array) {
@@ -142,7 +142,7 @@ void MSetCmd::DoCmd(PClient* client) {
   for (size_t index = 1; index != client->argv_.size(); index += 2) {
     kvs.push_back({client->argv_[index], client->argv_[index + 1]});
   }
-  storage::Status s = PSTORE.GetBackend(client->GetCurrentDB())->MSet(kvs);
+  storage::Status s = PSTORE.GetBackend(client->GetCurrentDB())->GetStorage()->MSet(kvs);
   if (s.ok()) {
     client->SetRes(CmdRes::kOK);
   } else {
@@ -167,7 +167,7 @@ void BitCountCmd::DoCmd(PClient* client) {
   storage::Status s;
   int32_t count = 0;
   if (client->argv_.size() == 2) {
-    s = PSTORE.GetBackend(client->GetCurrentDB())->BitCount(client->Key(), 0, 0, &count, false);
+    s = PSTORE.GetBackend(client->GetCurrentDB())->GetStorage()->BitCount(client->Key(), 0, 0, &count, false);
   } else {
     int64_t start_offset = 0;
     int64_t end_offset = 0;
@@ -177,7 +177,7 @@ void BitCountCmd::DoCmd(PClient* client) {
       return;
     }
 
-    s = PSTORE.GetBackend(client->GetCurrentDB())->BitCount(client->Key(), start_offset, end_offset, &count, true);
+    s = PSTORE.GetBackend(client->GetCurrentDB())->GetStorage()->BitCount(client->Key(), start_offset, end_offset, &count, true);
   }
 
   if (s.ok() || s.IsNotFound()) {
@@ -197,7 +197,7 @@ bool DecrCmd::DoInitial(pikiwidb::PClient* client) {
 
 void DecrCmd::DoCmd(pikiwidb::PClient* client) {
   int64_t ret = 0;
-  storage::Status s = PSTORE.GetBackend(client->GetCurrentDB())->Decrby(client->Key(), 1, &ret);
+  storage::Status s = PSTORE.GetBackend(client->GetCurrentDB())->GetStorage()->Decrby(client->Key(), 1, &ret);
   if (s.ok()) {
     client->AppendContent(":" + std::to_string(ret));
   } else if (s.IsCorruption() && s.ToString() == "Corruption: Value is not a integer") {
@@ -219,7 +219,7 @@ bool IncrCmd::DoInitial(pikiwidb::PClient* client) {
 
 void IncrCmd::DoCmd(pikiwidb::PClient* client) {
   int64_t ret = 0;
-  storage::Status s = PSTORE.GetBackend(client->GetCurrentDB())->Incrby(client->Key(), 1, &ret);
+  storage::Status s = PSTORE.GetBackend(client->GetCurrentDB())->GetStorage()->Incrby(client->Key(), 1, &ret);
   if (s.ok()) {
     client->AppendContent(":" + std::to_string(ret));
   } else if (s.IsCorruption() && s.ToString() == "Corruption: Value is not a integer") {
@@ -281,7 +281,7 @@ void BitOpCmd::DoCmd(PClient* client) {
     PString value;
     int64_t result_length = 0;
     storage::Status s =
-        PSTORE.GetBackend(client->GetCurrentDB())->BitOp(op, client->argv_[2], keys, value, &result_length);
+        PSTORE.GetBackend(client->GetCurrentDB())->GetStorage()->BitOp(op, client->argv_[2], keys, value, &result_length);
     if (s.ok()) {
       client->AppendInteger(result_length);
     } else {
@@ -300,7 +300,7 @@ bool StrlenCmd::DoInitial(PClient* client) {
 
 void StrlenCmd::DoCmd(PClient* client) {
   int32_t len = 0;
-  storage::Status s = PSTORE.GetBackend(client->GetCurrentDB())->Strlen(client->Key(), &len);
+  storage::Status s = PSTORE.GetBackend(client->GetCurrentDB())->GetStorage()->Strlen(client->Key(), &len);
   if (s.ok() || s.IsNotFound()) {
     client->AppendInteger(len);
   } else {
@@ -324,7 +324,7 @@ bool SetExCmd::DoInitial(PClient* client) {
 void SetExCmd::DoCmd(PClient* client) {
   int64_t sec = 0;
   pstd::String2int(client->argv_[2], &sec);
-  storage::Status s = PSTORE.GetBackend(client->GetCurrentDB())->Setex(client->Key(), client->argv_[3], sec);
+  storage::Status s = PSTORE.GetBackend(client->GetCurrentDB())->GetStorage()->Setex(client->Key(), client->argv_[3], sec);
   if (s.ok()) {
     client->SetRes(CmdRes::kOK);
   } else {
@@ -349,7 +349,7 @@ void PSetExCmd::DoCmd(PClient* client) {
   int64_t msec = 0;
   pstd::String2int(client->argv_[2], &msec);
   storage::Status s = PSTORE.GetBackend(client->GetCurrentDB())
-                          ->Setex(client->Key(), client->argv_[3], static_cast<int32_t>(msec / 1000));
+                          ->GetStorage()->Setex(client->Key(), client->argv_[3], static_cast<int32_t>(msec / 1000));
   if (s.ok()) {
     client->SetRes(CmdRes::kOK);
   } else {
@@ -374,7 +374,7 @@ void IncrbyCmd::DoCmd(PClient* client) {
   int64_t ret = 0;
   int64_t by = 0;
   pstd::String2int(client->argv_[2].data(), client->argv_[2].size(), &by);
-  storage::Status s = PSTORE.GetBackend(client->GetCurrentDB())->Incrby(client->Key(), by, &ret);
+  storage::Status s = PSTORE.GetBackend(client->GetCurrentDB())->GetStorage()->Incrby(client->Key(), by, &ret);
   if (s.ok()) {
     client->AppendContent(":" + std::to_string(ret));
   } else if (s.IsCorruption() && s.ToString() == "Corruption: Value is not a integer") {
@@ -406,7 +406,7 @@ void DecrbyCmd::DoCmd(PClient* client) {
     client->SetRes(CmdRes::kInvalidInt);
     return;
   }
-  storage::Status s = PSTORE.GetBackend(client->GetCurrentDB())->Decrby(client->Key(), by, &ret);
+  storage::Status s = PSTORE.GetBackend(client->GetCurrentDB())->GetStorage()->Decrby(client->Key(), by, &ret);
   if (s.ok()) {
     client->AppendContent(":" + std::to_string(ret));
   } else if (s.IsCorruption() && s.ToString() == "Corruption: Value is not a integer") {
@@ -433,7 +433,7 @@ bool IncrbyFloatCmd::DoInitial(PClient* client) {
 
 void IncrbyFloatCmd::DoCmd(PClient* client) {
   PString ret;
-  storage::Status s = PSTORE.GetBackend(client->GetCurrentDB())->Incrbyfloat(client->Key(), client->argv_[2], &ret);
+  storage::Status s = PSTORE.GetBackend(client->GetCurrentDB())->GetStorage()->Incrbyfloat(client->Key(), client->argv_[2], &ret);
   if (s.ok()) {
     client->AppendStringLen(ret.size());
     client->AppendContent(ret);
@@ -456,7 +456,7 @@ bool SetNXCmd::DoInitial(PClient* client) {
 
 void SetNXCmd::DoCmd(PClient* client) {
   int32_t success = 0;
-  storage::Status s = PSTORE.GetBackend(client->GetCurrentDB())->Setnx(client->Key(), client->argv_[2], &success);
+  storage::Status s = PSTORE.GetBackend(client->GetCurrentDB())->GetStorage()->Setnx(client->Key(), client->argv_[2], &success);
   if (s.ok()) {
     client->AppendInteger(success);
   } else {
@@ -479,7 +479,7 @@ void GetBitCmd::DoCmd(PClient* client) {
     client->SetRes(CmdRes::kInvalidInt);
     return;
   }
-  storage::Status s = PSTORE.GetBackend(client->GetCurrentDB())->GetBit(client->Key(), offset, &bit_val);
+  storage::Status s = PSTORE.GetBackend(client->GetCurrentDB())->GetStorage()->GetBit(client->Key(), offset, &bit_val);
   if (s.ok()) {
     client->AppendInteger(bit_val);
   } else {
@@ -510,7 +510,7 @@ void GetRangeCmd::DoCmd(PClient* client) {
   int64_t end = 0;
   pstd::String2int(client->argv_[2].data(), client->argv_[2].size(), &start);
   pstd::String2int(client->argv_[3].data(), client->argv_[3].size(), &end);
-  auto s = PSTORE.GetBackend(client->GetCurrentDB())->Getrange(client->Key(), start, end, &ret);
+  auto s = PSTORE.GetBackend(client->GetCurrentDB())->GetStorage()->Getrange(client->Key(), start, end, &ret);
   if (!s.ok()) {
     if (s.IsNotFound()) {
       client->AppendString("");
@@ -552,7 +552,7 @@ void SetBitCmd::DoCmd(PClient* client) {
   PString value;
   int32_t bit_val = 0;
   storage::Status s =
-      PSTORE.GetBackend(client->GetCurrentDB())->SetBit(client->Key(), offset, static_cast<int32_t>(on), &bit_val);
+      PSTORE.GetBackend(client->GetCurrentDB())->GetStorage()->SetBit(client->Key(), offset, static_cast<int32_t>(on), &bit_val);
   if (s.ok()) {
     client->AppendInteger(static_cast<int>(bit_val));
   } else {
@@ -578,7 +578,7 @@ void SetRangeCmd::DoCmd(PClient* client) {
 
   int32_t ret = 0;
   storage::Status s =
-      PSTORE.GetBackend(client->GetCurrentDB())->Setrange(client->Key(), offset, client->argv_[3], &ret);
+      PSTORE.GetBackend(client->GetCurrentDB())->GetStorage()->Setrange(client->Key(), offset, client->argv_[3], &ret);
   if (!s.ok()) {
     client->SetRes(CmdRes::kErrOther, "setrange cmd error");
     return;

--- a/src/cmd_kv.cc
+++ b/src/cmd_kv.cc
@@ -61,7 +61,8 @@ bool AppendCmd::DoInitial(PClient* client) {
 
 void AppendCmd::DoCmd(PClient* client) {
   int32_t new_len = 0;
-  storage::Status s = PSTORE.GetBackend(client->GetCurrentDB())->GetStorage()->Append(client->Key(), client->argv_[2], &new_len);
+  storage::Status s =
+      PSTORE.GetBackend(client->GetCurrentDB())->GetStorage()->Append(client->Key(), client->argv_[2], &new_len);
   if (s.ok() || s.IsNotFound()) {
     client->AppendInteger(new_len);
   } else {
@@ -79,7 +80,8 @@ bool GetSetCmd::DoInitial(PClient* client) {
 
 void GetSetCmd::DoCmd(PClient* client) {
   std::string old_value;
-  storage::Status s = PSTORE.GetBackend(client->GetCurrentDB())->GetStorage()->GetSet(client->Key(), client->argv_[2], &old_value);
+  storage::Status s =
+      PSTORE.GetBackend(client->GetCurrentDB())->GetStorage()->GetSet(client->Key(), client->argv_[2], &old_value);
   if (s.ok()) {
     if (old_value.empty()) {
       client->AppendContent("$-1");
@@ -104,7 +106,8 @@ bool MGetCmd::DoInitial(PClient* client) {
 
 void MGetCmd::DoCmd(PClient* client) {
   std::vector<storage::ValueStatus> db_value_status_array;
-  storage::Status s = PSTORE.GetBackend(client->GetCurrentDB())->GetStorage()->MGet(client->Keys(), &db_value_status_array);
+  storage::Status s =
+      PSTORE.GetBackend(client->GetCurrentDB())->GetStorage()->MGet(client->Keys(), &db_value_status_array);
   if (s.ok()) {
     client->AppendArrayLen(db_value_status_array.size());
     for (const auto& vs : db_value_status_array) {
@@ -177,7 +180,9 @@ void BitCountCmd::DoCmd(PClient* client) {
       return;
     }
 
-    s = PSTORE.GetBackend(client->GetCurrentDB())->GetStorage()->BitCount(client->Key(), start_offset, end_offset, &count, true);
+    s = PSTORE.GetBackend(client->GetCurrentDB())
+            ->GetStorage()
+            ->BitCount(client->Key(), start_offset, end_offset, &count, true);
   }
 
   if (s.ok() || s.IsNotFound()) {
@@ -280,8 +285,9 @@ void BitOpCmd::DoCmd(PClient* client) {
   } else {
     PString value;
     int64_t result_length = 0;
-    storage::Status s =
-        PSTORE.GetBackend(client->GetCurrentDB())->GetStorage()->BitOp(op, client->argv_[2], keys, value, &result_length);
+    storage::Status s = PSTORE.GetBackend(client->GetCurrentDB())
+                            ->GetStorage()
+                            ->BitOp(op, client->argv_[2], keys, value, &result_length);
     if (s.ok()) {
       client->AppendInteger(result_length);
     } else {
@@ -324,7 +330,8 @@ bool SetExCmd::DoInitial(PClient* client) {
 void SetExCmd::DoCmd(PClient* client) {
   int64_t sec = 0;
   pstd::String2int(client->argv_[2], &sec);
-  storage::Status s = PSTORE.GetBackend(client->GetCurrentDB())->GetStorage()->Setex(client->Key(), client->argv_[3], sec);
+  storage::Status s =
+      PSTORE.GetBackend(client->GetCurrentDB())->GetStorage()->Setex(client->Key(), client->argv_[3], sec);
   if (s.ok()) {
     client->SetRes(CmdRes::kOK);
   } else {
@@ -349,7 +356,8 @@ void PSetExCmd::DoCmd(PClient* client) {
   int64_t msec = 0;
   pstd::String2int(client->argv_[2], &msec);
   storage::Status s = PSTORE.GetBackend(client->GetCurrentDB())
-                          ->GetStorage()->Setex(client->Key(), client->argv_[3], static_cast<int32_t>(msec / 1000));
+                          ->GetStorage()
+                          ->Setex(client->Key(), client->argv_[3], static_cast<int32_t>(msec / 1000));
   if (s.ok()) {
     client->SetRes(CmdRes::kOK);
   } else {
@@ -433,7 +441,8 @@ bool IncrbyFloatCmd::DoInitial(PClient* client) {
 
 void IncrbyFloatCmd::DoCmd(PClient* client) {
   PString ret;
-  storage::Status s = PSTORE.GetBackend(client->GetCurrentDB())->GetStorage()->Incrbyfloat(client->Key(), client->argv_[2], &ret);
+  storage::Status s =
+      PSTORE.GetBackend(client->GetCurrentDB())->GetStorage()->Incrbyfloat(client->Key(), client->argv_[2], &ret);
   if (s.ok()) {
     client->AppendStringLen(ret.size());
     client->AppendContent(ret);
@@ -456,7 +465,8 @@ bool SetNXCmd::DoInitial(PClient* client) {
 
 void SetNXCmd::DoCmd(PClient* client) {
   int32_t success = 0;
-  storage::Status s = PSTORE.GetBackend(client->GetCurrentDB())->GetStorage()->Setnx(client->Key(), client->argv_[2], &success);
+  storage::Status s =
+      PSTORE.GetBackend(client->GetCurrentDB())->GetStorage()->Setnx(client->Key(), client->argv_[2], &success);
   if (s.ok()) {
     client->AppendInteger(success);
   } else {
@@ -551,8 +561,9 @@ void SetBitCmd::DoCmd(PClient* client) {
 
   PString value;
   int32_t bit_val = 0;
-  storage::Status s =
-      PSTORE.GetBackend(client->GetCurrentDB())->GetStorage()->SetBit(client->Key(), offset, static_cast<int32_t>(on), &bit_val);
+  storage::Status s = PSTORE.GetBackend(client->GetCurrentDB())
+                          ->GetStorage()
+                          ->SetBit(client->Key(), offset, static_cast<int32_t>(on), &bit_val);
   if (s.ok()) {
     client->AppendInteger(static_cast<int>(bit_val));
   } else {

--- a/src/cmd_list.cc
+++ b/src/cmd_list.cc
@@ -21,7 +21,8 @@ bool LPushCmd::DoInitial(PClient* client) {
 void LPushCmd::DoCmd(PClient* client) {
   std::vector<std::string> list_values(client->argv_.begin() + 2, client->argv_.end());
   uint64_t reply_num = 0;
-  storage::Status s = PSTORE.GetBackend(client->GetCurrentDB())->GetStorage()->LPush(client->Key(), list_values, &reply_num);
+  storage::Status s =
+      PSTORE.GetBackend(client->GetCurrentDB())->GetStorage()->LPush(client->Key(), list_values, &reply_num);
   if (s.ok()) {
     client->AppendInteger(reply_num);
   } else {
@@ -40,7 +41,8 @@ bool LPushxCmd::DoInitial(PClient* client) {
 void LPushxCmd::DoCmd(PClient* client) {
   std::vector<std::string> list_values(client->argv_.begin() + 2, client->argv_.end());
   uint64_t reply_num = 0;
-  storage::Status s = PSTORE.GetBackend(client->GetCurrentDB())->GetStorage()->LPushx(client->Key(), list_values, &reply_num);
+  storage::Status s =
+      PSTORE.GetBackend(client->GetCurrentDB())->GetStorage()->LPushx(client->Key(), list_values, &reply_num);
   if (s.ok() || s.IsNotFound()) {
     client->AppendInteger(reply_num);
   } else {
@@ -59,7 +61,8 @@ bool RPushCmd::DoInitial(PClient* client) {
 void RPushCmd::DoCmd(PClient* client) {
   std::vector<std::string> list_values(client->argv_.begin() + 2, client->argv_.end());
   uint64_t reply_num = 0;
-  storage::Status s = PSTORE.GetBackend(client->GetCurrentDB())->GetStorage()->RPush(client->Key(), list_values, &reply_num);
+  storage::Status s =
+      PSTORE.GetBackend(client->GetCurrentDB())->GetStorage()->RPush(client->Key(), list_values, &reply_num);
   if (s.ok()) {
     client->AppendInteger(reply_num);
   } else {
@@ -78,7 +81,8 @@ bool RPushxCmd::DoInitial(PClient* client) {
 void RPushxCmd::DoCmd(PClient* client) {
   std::vector<std::string> list_values(client->argv_.begin() + 2, client->argv_.end());
   uint64_t reply_num = 0;
-  storage::Status s = PSTORE.GetBackend(client->GetCurrentDB())->GetStorage()->RPushx(client->Key(), list_values, &reply_num);
+  storage::Status s =
+      PSTORE.GetBackend(client->GetCurrentDB())->GetStorage()->RPushx(client->Key(), list_values, &reply_num);
   if (s.ok() || s.IsNotFound()) {
     client->AppendInteger(reply_num);
   } else {
@@ -142,7 +146,8 @@ void LRangeCmd::DoCmd(PClient* client) {
     client->SetRes(CmdRes::kInvalidInt);
     return;
   }
-  storage::Status s = PSTORE.GetBackend(client->GetCurrentDB())->GetStorage()->LRange(client->Key(), start_index, end_index, &ret);
+  storage::Status s =
+      PSTORE.GetBackend(client->GetCurrentDB())->GetStorage()->LRange(client->Key(), start_index, end_index, &ret);
   if (!s.ok() && !s.IsNotFound()) {
     client->SetRes(CmdRes::kSyntaxErr, "lrange cmd error");
     return;
@@ -192,7 +197,8 @@ void LTrimCmd::DoCmd(PClient* client) {
     client->SetRes(CmdRes::kInvalidInt);
     return;
   }
-  storage::Status s = PSTORE.GetBackend(client->GetCurrentDB())->GetStorage()->LTrim(client->Key(), start_index, end_index);
+  storage::Status s =
+      PSTORE.GetBackend(client->GetCurrentDB())->GetStorage()->LTrim(client->Key(), start_index, end_index);
   if (s.ok() || s.IsNotFound()) {
     client->SetRes(CmdRes::kOK);
   } else {
@@ -219,7 +225,8 @@ void LSetCmd::DoCmd(PClient* client) {
       client->SetRes(CmdRes::kErrOther, "lset cmd error");  // this will not happend in normal case
       return;
     }
-    storage::Status s = PSTORE.GetBackend(client->GetCurrentDB())->GetStorage()->LSet(client->Key(), val, client->argv_[3]);
+    storage::Status s =
+        PSTORE.GetBackend(client->GetCurrentDB())->GetStorage()->LSet(client->Key(), val, client->argv_[3]);
     if (s.ok()) {
       client->SetRes(CmdRes::kOK);
     } else if (s.IsNotFound()) {
@@ -253,7 +260,8 @@ void LInsertCmd::DoCmd(PClient* client) {
     before_or_after = storage::After;
   }
   storage::Status s = PSTORE.GetBackend(client->GetCurrentDB())
-                          ->GetStorage()->LInsert(client->Key(), before_or_after, client->argv_[3], client->argv_[4], &ret);
+                          ->GetStorage()
+                          ->LInsert(client->Key(), before_or_after, client->argv_[3], client->argv_[4], &ret);
   if (!s.ok() && s.IsNotFound()) {
     client->SetRes(CmdRes::kSyntaxErr, "linsert cmd error");  // just a safeguard
     return;

--- a/src/cmd_list.cc
+++ b/src/cmd_list.cc
@@ -21,7 +21,7 @@ bool LPushCmd::DoInitial(PClient* client) {
 void LPushCmd::DoCmd(PClient* client) {
   std::vector<std::string> list_values(client->argv_.begin() + 2, client->argv_.end());
   uint64_t reply_num = 0;
-  storage::Status s = PSTORE.GetBackend(client->GetCurrentDB())->LPush(client->Key(), list_values, &reply_num);
+  storage::Status s = PSTORE.GetBackend(client->GetCurrentDB())->GetStorage()->LPush(client->Key(), list_values, &reply_num);
   if (s.ok()) {
     client->AppendInteger(reply_num);
   } else {
@@ -40,7 +40,7 @@ bool LPushxCmd::DoInitial(PClient* client) {
 void LPushxCmd::DoCmd(PClient* client) {
   std::vector<std::string> list_values(client->argv_.begin() + 2, client->argv_.end());
   uint64_t reply_num = 0;
-  storage::Status s = PSTORE.GetBackend(client->GetCurrentDB())->LPushx(client->Key(), list_values, &reply_num);
+  storage::Status s = PSTORE.GetBackend(client->GetCurrentDB())->GetStorage()->LPushx(client->Key(), list_values, &reply_num);
   if (s.ok() || s.IsNotFound()) {
     client->AppendInteger(reply_num);
   } else {
@@ -59,7 +59,7 @@ bool RPushCmd::DoInitial(PClient* client) {
 void RPushCmd::DoCmd(PClient* client) {
   std::vector<std::string> list_values(client->argv_.begin() + 2, client->argv_.end());
   uint64_t reply_num = 0;
-  storage::Status s = PSTORE.GetBackend(client->GetCurrentDB())->RPush(client->Key(), list_values, &reply_num);
+  storage::Status s = PSTORE.GetBackend(client->GetCurrentDB())->GetStorage()->RPush(client->Key(), list_values, &reply_num);
   if (s.ok()) {
     client->AppendInteger(reply_num);
   } else {
@@ -78,7 +78,7 @@ bool RPushxCmd::DoInitial(PClient* client) {
 void RPushxCmd::DoCmd(PClient* client) {
   std::vector<std::string> list_values(client->argv_.begin() + 2, client->argv_.end());
   uint64_t reply_num = 0;
-  storage::Status s = PSTORE.GetBackend(client->GetCurrentDB())->RPushx(client->Key(), list_values, &reply_num);
+  storage::Status s = PSTORE.GetBackend(client->GetCurrentDB())->GetStorage()->RPushx(client->Key(), list_values, &reply_num);
   if (s.ok() || s.IsNotFound()) {
     client->AppendInteger(reply_num);
   } else {
@@ -96,7 +96,7 @@ bool LPopCmd::DoInitial(PClient* client) {
 
 void LPopCmd::DoCmd(PClient* client) {
   std::vector<std::string> elements;
-  storage::Status s = PSTORE.GetBackend(client->GetCurrentDB())->LPop(client->Key(), 1, &elements);
+  storage::Status s = PSTORE.GetBackend(client->GetCurrentDB())->GetStorage()->LPop(client->Key(), 1, &elements);
   if (s.ok()) {
     client->AppendString(elements[0]);
   } else if (s.IsNotFound()) {
@@ -116,7 +116,7 @@ bool RPopCmd::DoInitial(PClient* client) {
 
 void RPopCmd::DoCmd(PClient* client) {
   std::vector<std::string> elements;
-  storage::Status s = PSTORE.GetBackend(client->GetCurrentDB())->RPop(client->Key(), 1, &elements);
+  storage::Status s = PSTORE.GetBackend(client->GetCurrentDB())->GetStorage()->RPop(client->Key(), 1, &elements);
   if (s.ok()) {
     client->AppendString(elements[0]);
   } else if (s.IsNotFound()) {
@@ -142,7 +142,7 @@ void LRangeCmd::DoCmd(PClient* client) {
     client->SetRes(CmdRes::kInvalidInt);
     return;
   }
-  storage::Status s = PSTORE.GetBackend(client->GetCurrentDB())->LRange(client->Key(), start_index, end_index, &ret);
+  storage::Status s = PSTORE.GetBackend(client->GetCurrentDB())->GetStorage()->LRange(client->Key(), start_index, end_index, &ret);
   if (!s.ok() && !s.IsNotFound()) {
     client->SetRes(CmdRes::kSyntaxErr, "lrange cmd error");
     return;
@@ -168,7 +168,7 @@ void LRemCmd::DoCmd(PClient* client) {
 
   uint64_t reply_num = 0;
   storage::Status s =
-      PSTORE.GetBackend(client->GetCurrentDB())->LRem(client->Key(), freq_, client->argv_[3], &reply_num);
+      PSTORE.GetBackend(client->GetCurrentDB())->GetStorage()->LRem(client->Key(), freq_, client->argv_[3], &reply_num);
   if (s.ok() || s.IsNotFound()) {
     client->AppendInteger(reply_num);
   } else {
@@ -192,7 +192,7 @@ void LTrimCmd::DoCmd(PClient* client) {
     client->SetRes(CmdRes::kInvalidInt);
     return;
   }
-  storage::Status s = PSTORE.GetBackend(client->GetCurrentDB())->LTrim(client->Key(), start_index, end_index);
+  storage::Status s = PSTORE.GetBackend(client->GetCurrentDB())->GetStorage()->LTrim(client->Key(), start_index, end_index);
   if (s.ok() || s.IsNotFound()) {
     client->SetRes(CmdRes::kOK);
   } else {
@@ -219,7 +219,7 @@ void LSetCmd::DoCmd(PClient* client) {
       client->SetRes(CmdRes::kErrOther, "lset cmd error");  // this will not happend in normal case
       return;
     }
-    storage::Status s = PSTORE.GetBackend(client->GetCurrentDB())->LSet(client->Key(), val, client->argv_[3]);
+    storage::Status s = PSTORE.GetBackend(client->GetCurrentDB())->GetStorage()->LSet(client->Key(), val, client->argv_[3]);
     if (s.ok()) {
       client->SetRes(CmdRes::kOK);
     } else if (s.IsNotFound()) {
@@ -253,7 +253,7 @@ void LInsertCmd::DoCmd(PClient* client) {
     before_or_after = storage::After;
   }
   storage::Status s = PSTORE.GetBackend(client->GetCurrentDB())
-                          ->LInsert(client->Key(), before_or_after, client->argv_[3], client->argv_[4], &ret);
+                          ->GetStorage()->LInsert(client->Key(), before_or_after, client->argv_[3], client->argv_[4], &ret);
   if (!s.ok() && s.IsNotFound()) {
     client->SetRes(CmdRes::kSyntaxErr, "linsert cmd error");  // just a safeguard
     return;
@@ -278,7 +278,7 @@ void LIndexCmd::DoCmd(PClient* client) {
   }
 
   std::string value;
-  storage::Status s = PSTORE.GetBackend(client->GetCurrentDB())->LIndex(client->Key(), freq_, &value);
+  storage::Status s = PSTORE.GetBackend(client->GetCurrentDB())->GetStorage()->LIndex(client->Key(), freq_, &value);
   if (s.ok()) {
     client->AppendString(value);
   } else if (s.IsNotFound()) {
@@ -298,7 +298,7 @@ bool LLenCmd::DoInitial(PClient* client) {
 
 void LLenCmd::DoCmd(PClient* client) {
   uint64_t llen = 0;
-  storage::Status s = PSTORE.GetBackend(client->GetCurrentDB())->LLen(client->Key(), &llen);
+  storage::Status s = PSTORE.GetBackend(client->GetCurrentDB())->GetStorage()->LLen(client->Key(), &llen);
   if (s.ok() || s.IsNotFound()) {
     client->AppendInteger(static_cast<int64_t>(llen));
   } else {

--- a/src/cmd_set.cc
+++ b/src/cmd_set.cc
@@ -22,7 +22,7 @@ bool SIsMemberCmd::DoInitial(PClient* client) {
 }
 void SIsMemberCmd::DoCmd(PClient* client) {
   int32_t reply_Num = 0;  // only change to 1 if ismember . key not exist it is 0
-  PSTORE.GetBackend(client->GetCurrentDB())->SIsmember(client->Key(), client->argv_[2], &reply_Num);
+  PSTORE.GetBackend(client->GetCurrentDB())-> GetStorage()->SIsmember(client->Key(), client->argv_[2], &reply_Num);
 
   client->AppendInteger(reply_Num);
 }
@@ -39,7 +39,7 @@ bool SAddCmd::DoInitial(PClient* client) {
 void SAddCmd::DoCmd(PClient* client) {
   const std::vector<std::string> members(client->argv_.begin() + 2, client->argv_.end());
   int32_t ret = 0;
-  storage::Status s = PSTORE.GetBackend(client->GetCurrentDB())->SAdd(client->Key(), members, &ret);
+  storage::Status s = PSTORE.GetBackend(client->GetCurrentDB())->GetStorage()->SAdd(client->Key(), members, &ret);
   if (s.ok()) {
     client->AppendInteger(ret);
   } else {
@@ -61,7 +61,7 @@ void SUnionStoreCmd::DoCmd(PClient* client) {
   std::vector<std::string> value_to_dest;
   int32_t ret = 0;
   storage::Status s =
-      PSTORE.GetBackend(client->GetCurrentDB())->SUnionstore(client->Keys().at(0), keys, value_to_dest, &ret);
+      PSTORE.GetBackend(client->GetCurrentDB())->GetStorage()->SUnionstore(client->Keys().at(0), keys, value_to_dest, &ret);
   if (!s.ok()) {
     client->SetRes(CmdRes::kSyntaxErr, "sunionstore cmd error");
   }
@@ -79,7 +79,7 @@ bool SInterCmd::DoInitial(PClient* client) {
 
 void SInterCmd::DoCmd(PClient* client) {
   std::vector<std::string> res_vt;
-  storage::Status s = PSTORE.GetBackend(client->GetCurrentDB())->SInter(client->Keys(), &res_vt);
+  storage::Status s = PSTORE.GetBackend(client->GetCurrentDB())->GetStorage()->SInter(client->Keys(), &res_vt);
   if (!s.ok()) {
     client->SetRes(CmdRes::kErrOther, "sinter cmd error");
     return;
@@ -98,7 +98,7 @@ bool SRemCmd::DoInitial(PClient* client) {
 void SRemCmd::DoCmd(PClient* client) {
   std::vector<std::string> to_delete_members(client->argv_.begin() + 2, client->argv_.end());
   int32_t reply_num = 0;
-  storage::Status s = PSTORE.GetBackend(client->GetCurrentDB())->SRem(client->Key(), to_delete_members, &reply_num);
+  storage::Status s = PSTORE.GetBackend(client->GetCurrentDB())->GetStorage()->SRem(client->Key(), to_delete_members, &reply_num);
   if (!s.ok()) {
     client->SetRes(CmdRes::kErrOther, "srem cmd error");
   }
@@ -116,7 +116,7 @@ bool SUnionCmd::DoInitial(PClient* client) {
 
 void SUnionCmd::DoCmd(PClient* client) {
   std::vector<std::string> res_vt;
-  storage::Status s = PSTORE.GetBackend(client->GetCurrentDB())->SUnion(client->Keys(), &res_vt);
+  storage::Status s = PSTORE.GetBackend(client->GetCurrentDB())->GetStorage()->SUnion(client->Keys(), &res_vt);
   if (!s.ok()) {
     client->SetRes(CmdRes::kErrOther, "sunion cmd error");
   }
@@ -137,7 +137,7 @@ void SInterStoreCmd::DoCmd(PClient* client) {
 
   std::vector<std::string> inter_keys(client->argv_.begin() + 2, client->argv_.end());
   storage::Status s =
-      PSTORE.GetBackend(client->GetCurrentDB())->SInterstore(client->Key(), inter_keys, value_to_dest, &reply_num);
+      PSTORE.GetBackend(client->GetCurrentDB())->GetStorage()->SInterstore(client->Key(), inter_keys, value_to_dest, &reply_num);
   if (!s.ok()) {
     client->SetRes(CmdRes::kSyntaxErr, "sinterstore cmd error");
     return;
@@ -154,7 +154,7 @@ bool SCardCmd::DoInitial(PClient* client) {
 }
 void SCardCmd::DoCmd(PClient* client) {
   int32_t reply_Num = 0;
-  storage::Status s = PSTORE.GetBackend(client->GetCurrentDB())->SCard(client->Key(), &reply_Num);
+  storage::Status s = PSTORE.GetBackend(client->GetCurrentDB())->GetStorage()->SCard(client->Key(), &reply_Num);
   if (!s.ok()) {
     client->SetRes(CmdRes::kSyntaxErr, "scard cmd error");
     return;
@@ -170,7 +170,7 @@ bool SMoveCmd::DoInitial(PClient* client) { return true; }
 void SMoveCmd::DoCmd(PClient* client) {
   int32_t reply_num = 0;
   storage::Status s = PSTORE.GetBackend(client->GetCurrentDB())
-                          ->SMove(client->argv_[1], client->argv_[2], client->argv_[3], &reply_num);
+                          -> GetStorage()->SMove(client->argv_[1], client->argv_[2], client->argv_[3], &reply_num);
   if (!s.ok()) {
     client->SetRes(CmdRes::kErrOther, "smove cmd error");
     return;
@@ -198,7 +198,7 @@ bool SRandMemberCmd::DoInitial(PClient* client) {
 
 void SRandMemberCmd::DoCmd(PClient* client) {
   std::vector<std::string> vec_ret;
-  storage::Status s = PSTORE.GetBackend(client->GetCurrentDB())->SRandmember(client->Key(), this->num_rand, &vec_ret);
+  storage::Status s = PSTORE.GetBackend(client->GetCurrentDB())->GetStorage()->SRandmember(client->Key(), this->num_rand, &vec_ret);
   if (!s.ok()) {
     client->SetRes(CmdRes::kSyntaxErr, "srandmember cmd error");
     return;
@@ -224,7 +224,7 @@ void SPopCmd::DoCmd(PClient* client) {
   if ((client->argv_.size()) == 2) {
     int64_t cnt = 1;
     std::vector<std::string> delete_member;
-    storage::Status s = PSTORE.GetBackend(client->GetCurrentDB())->SPop(client->Key(), &delete_member, cnt);
+    storage::Status s = PSTORE.GetBackend(client->GetCurrentDB())->GetStorage()->SPop(client->Key(), &delete_member, cnt);
     if (!s.ok()) {
       client->SetRes(CmdRes::kSyntaxErr, "spop cmd error");
       return;
@@ -238,7 +238,7 @@ void SPopCmd::DoCmd(PClient* client) {
       client->SetRes(CmdRes::kInvalidInt);
       return;
     }
-    storage::Status s = PSTORE.GetBackend(client->GetCurrentDB())->SPop(client->Key(), &delete_members, cnt);
+    storage::Status s = PSTORE.GetBackend(client->GetCurrentDB())->GetStorage()->SPop(client->Key(), &delete_members, cnt);
     if (!s.ok()) {
       client->SetRes(CmdRes::kSyntaxErr, "spop cmd error");
       return;
@@ -261,7 +261,7 @@ bool SMembersCmd::DoInitial(PClient* client) {
 
 void SMembersCmd::DoCmd(PClient* client) {
   std::vector<std::string> delete_members;
-  storage::Status s = PSTORE.GetBackend(client->GetCurrentDB())->SMembers(client->Key(), &delete_members);
+  storage::Status s = PSTORE.GetBackend(client->GetCurrentDB())->GetStorage()->SMembers(client->Key(), &delete_members);
   if (!s.ok()) {
     client->SetRes(CmdRes::kSyntaxErr, "smembers cmd error");
     return;
@@ -280,7 +280,7 @@ bool SDiffCmd::DoInitial(PClient* client) {
 void SDiffCmd::DoCmd(PClient* client) {
   std::vector<std::string> diff_members;
   std::vector<std::string> diff_keys(client->argv_.begin() + 1, client->argv_.end());
-  storage::Status s = PSTORE.GetBackend(client->GetCurrentDB())->SDiff(diff_keys, &diff_members);
+  storage::Status s = PSTORE.GetBackend(client->GetCurrentDB())->GetStorage()->SDiff(diff_keys, &diff_members);
   if (!s.ok()) {
     client->SetRes(CmdRes::kSyntaxErr, "sdiff cmd error");
     return;
@@ -301,7 +301,7 @@ void SDiffstoreCmd::DoCmd(PClient* client) {
   int32_t reply_num = 0;
   std::vector<std::string> diffstore_keys(client->argv_.begin() + 2, client->argv_.end());
   storage::Status s =
-      PSTORE.GetBackend(client->GetCurrentDB())->SDiffstore(client->Key(), diffstore_keys, value_to_dest, &reply_num);
+      PSTORE.GetBackend(client->GetCurrentDB())->GetStorage()->SDiffstore(client->Key(), diffstore_keys, value_to_dest, &reply_num);
   if (!s.ok()) {
     client->SetRes(CmdRes::kSyntaxErr, "sdiffstore cmd error");
     return;

--- a/src/cmd_set.cc
+++ b/src/cmd_set.cc
@@ -22,7 +22,7 @@ bool SIsMemberCmd::DoInitial(PClient* client) {
 }
 void SIsMemberCmd::DoCmd(PClient* client) {
   int32_t reply_Num = 0;  // only change to 1 if ismember . key not exist it is 0
-  PSTORE.GetBackend(client->GetCurrentDB())-> GetStorage()->SIsmember(client->Key(), client->argv_[2], &reply_Num);
+  PSTORE.GetBackend(client->GetCurrentDB())->GetStorage()->SIsmember(client->Key(), client->argv_[2], &reply_Num);
 
   client->AppendInteger(reply_Num);
 }
@@ -60,8 +60,9 @@ void SUnionStoreCmd::DoCmd(PClient* client) {
   std::vector<std::string> keys(client->Keys().begin() + 1, client->Keys().end());
   std::vector<std::string> value_to_dest;
   int32_t ret = 0;
-  storage::Status s =
-      PSTORE.GetBackend(client->GetCurrentDB())->GetStorage()->SUnionstore(client->Keys().at(0), keys, value_to_dest, &ret);
+  storage::Status s = PSTORE.GetBackend(client->GetCurrentDB())
+                          ->GetStorage()
+                          ->SUnionstore(client->Keys().at(0), keys, value_to_dest, &ret);
   if (!s.ok()) {
     client->SetRes(CmdRes::kSyntaxErr, "sunionstore cmd error");
   }
@@ -98,7 +99,8 @@ bool SRemCmd::DoInitial(PClient* client) {
 void SRemCmd::DoCmd(PClient* client) {
   std::vector<std::string> to_delete_members(client->argv_.begin() + 2, client->argv_.end());
   int32_t reply_num = 0;
-  storage::Status s = PSTORE.GetBackend(client->GetCurrentDB())->GetStorage()->SRem(client->Key(), to_delete_members, &reply_num);
+  storage::Status s =
+      PSTORE.GetBackend(client->GetCurrentDB())->GetStorage()->SRem(client->Key(), to_delete_members, &reply_num);
   if (!s.ok()) {
     client->SetRes(CmdRes::kErrOther, "srem cmd error");
   }
@@ -136,8 +138,9 @@ void SInterStoreCmd::DoCmd(PClient* client) {
   int32_t reply_num = 0;
 
   std::vector<std::string> inter_keys(client->argv_.begin() + 2, client->argv_.end());
-  storage::Status s =
-      PSTORE.GetBackend(client->GetCurrentDB())->GetStorage()->SInterstore(client->Key(), inter_keys, value_to_dest, &reply_num);
+  storage::Status s = PSTORE.GetBackend(client->GetCurrentDB())
+                          ->GetStorage()
+                          ->SInterstore(client->Key(), inter_keys, value_to_dest, &reply_num);
   if (!s.ok()) {
     client->SetRes(CmdRes::kSyntaxErr, "sinterstore cmd error");
     return;
@@ -170,7 +173,8 @@ bool SMoveCmd::DoInitial(PClient* client) { return true; }
 void SMoveCmd::DoCmd(PClient* client) {
   int32_t reply_num = 0;
   storage::Status s = PSTORE.GetBackend(client->GetCurrentDB())
-                          -> GetStorage()->SMove(client->argv_[1], client->argv_[2], client->argv_[3], &reply_num);
+                          ->GetStorage()
+                          ->SMove(client->argv_[1], client->argv_[2], client->argv_[3], &reply_num);
   if (!s.ok()) {
     client->SetRes(CmdRes::kErrOther, "smove cmd error");
     return;
@@ -198,7 +202,8 @@ bool SRandMemberCmd::DoInitial(PClient* client) {
 
 void SRandMemberCmd::DoCmd(PClient* client) {
   std::vector<std::string> vec_ret;
-  storage::Status s = PSTORE.GetBackend(client->GetCurrentDB())->GetStorage()->SRandmember(client->Key(), this->num_rand, &vec_ret);
+  storage::Status s =
+      PSTORE.GetBackend(client->GetCurrentDB())->GetStorage()->SRandmember(client->Key(), this->num_rand, &vec_ret);
   if (!s.ok()) {
     client->SetRes(CmdRes::kSyntaxErr, "srandmember cmd error");
     return;
@@ -224,7 +229,8 @@ void SPopCmd::DoCmd(PClient* client) {
   if ((client->argv_.size()) == 2) {
     int64_t cnt = 1;
     std::vector<std::string> delete_member;
-    storage::Status s = PSTORE.GetBackend(client->GetCurrentDB())->GetStorage()->SPop(client->Key(), &delete_member, cnt);
+    storage::Status s =
+        PSTORE.GetBackend(client->GetCurrentDB())->GetStorage()->SPop(client->Key(), &delete_member, cnt);
     if (!s.ok()) {
       client->SetRes(CmdRes::kSyntaxErr, "spop cmd error");
       return;
@@ -238,7 +244,8 @@ void SPopCmd::DoCmd(PClient* client) {
       client->SetRes(CmdRes::kInvalidInt);
       return;
     }
-    storage::Status s = PSTORE.GetBackend(client->GetCurrentDB())->GetStorage()->SPop(client->Key(), &delete_members, cnt);
+    storage::Status s =
+        PSTORE.GetBackend(client->GetCurrentDB())->GetStorage()->SPop(client->Key(), &delete_members, cnt);
     if (!s.ok()) {
       client->SetRes(CmdRes::kSyntaxErr, "spop cmd error");
       return;
@@ -300,8 +307,9 @@ void SDiffstoreCmd::DoCmd(PClient* client) {
   std::vector<std::string> value_to_dest;
   int32_t reply_num = 0;
   std::vector<std::string> diffstore_keys(client->argv_.begin() + 2, client->argv_.end());
-  storage::Status s =
-      PSTORE.GetBackend(client->GetCurrentDB())->GetStorage()->SDiffstore(client->Key(), diffstore_keys, value_to_dest, &reply_num);
+  storage::Status s = PSTORE.GetBackend(client->GetCurrentDB())
+                          ->GetStorage()
+                          ->SDiffstore(client->Key(), diffstore_keys, value_to_dest, &reply_num);
   if (!s.ok()) {
     client->SetRes(CmdRes::kSyntaxErr, "sdiffstore cmd error");
     return;

--- a/src/cmd_zset.cc
+++ b/src/cmd_zset.cc
@@ -74,7 +74,7 @@ void ZAddCmd::DoCmd(PClient* client) {
   }
   client->SetKey(client->argv_[1]);
   int32_t count = 0;
-  storage::Status s = PSTORE.GetBackend(client->GetCurrentDB())->ZAdd(client->Key(), score_members_, &count);
+  storage::Status s = PSTORE.GetBackend(client->GetCurrentDB())->GetStorage()->ZAdd(client->Key(), score_members_, &count);
   if (s.ok()) {
     client->AppendInteger(count);
   } else {
@@ -112,7 +112,7 @@ void ZRevrangeCmd::DoCmd(PClient* client) {
   std::vector<storage::ScoreMember> score_members;
   storage::Status s =
       PSTORE.GetBackend(client->GetCurrentDB())
-          ->ZRevrange(client->Key(), static_cast<int32_t>(start), static_cast<int32_t>(stop), &score_members);
+          ->GetStorage()->ZRevrange(client->Key(), static_cast<int32_t>(start), static_cast<int32_t>(stop), &score_members);
   if (s.ok() || s.IsNotFound()) {
     if (is_ws) {
       char buf[32];
@@ -189,7 +189,7 @@ void ZRangebyscoreCmd::DoCmd(PClient* client) {
   }
   std::vector<storage::ScoreMember> score_members;
   storage::Status s = PSTORE.GetBackend(client->GetCurrentDB())
-                          ->ZRangebyscore(client->Key(), min_score, max_score, left_close, right_close, &score_members);
+                          ->GetStorage()->ZRangebyscore(client->Key(), min_score, max_score, left_close, right_close, &score_members);
   if (!s.ok() && !s.IsNotFound()) {
     client->SetRes(CmdRes::kErrOther, s.ToString());
     return;
@@ -227,7 +227,7 @@ bool ZCardCmd::DoInitial(PClient* client) {
 
 void ZCardCmd::DoCmd(PClient* client) {
   int32_t reply_Num = 0;
-  storage::Status s = PSTORE.GetBackend(client->GetCurrentDB())->ZCard(client->Key(), &reply_Num);
+  storage::Status s = PSTORE.GetBackend(client->GetCurrentDB())->GetStorage()->ZCard(client->Key(), &reply_Num);
   if (!s.ok()) {
     client->SetRes(CmdRes::kSyntaxErr, "ZCard cmd error");
     return;
@@ -290,7 +290,7 @@ void ZRevRangeByScoreCmd::DoCmd(PClient* client) {
   }
   std::vector<storage::ScoreMember> score_members;
   storage::Status s = PSTORE.GetBackend(client->GetCurrentDB())
-                          ->ZRevrangebyscore(client->Key(), min_score, max_score, left_close, right_close, count,
+                          ->GetStorage()->ZRevrangebyscore(client->Key(), min_score, max_score, left_close, right_close, count,
                                              offset, &score_members);
   if (!s.ok() && !s.IsNotFound()) {
     client->SetRes(CmdRes::kErrOther, s.ToString());

--- a/src/cmd_zset.cc
+++ b/src/cmd_zset.cc
@@ -74,7 +74,8 @@ void ZAddCmd::DoCmd(PClient* client) {
   }
   client->SetKey(client->argv_[1]);
   int32_t count = 0;
-  storage::Status s = PSTORE.GetBackend(client->GetCurrentDB())->GetStorage()->ZAdd(client->Key(), score_members_, &count);
+  storage::Status s =
+      PSTORE.GetBackend(client->GetCurrentDB())->GetStorage()->ZAdd(client->Key(), score_members_, &count);
   if (s.ok()) {
     client->AppendInteger(count);
   } else {
@@ -112,7 +113,8 @@ void ZRevrangeCmd::DoCmd(PClient* client) {
   std::vector<storage::ScoreMember> score_members;
   storage::Status s =
       PSTORE.GetBackend(client->GetCurrentDB())
-          ->GetStorage()->ZRevrange(client->Key(), static_cast<int32_t>(start), static_cast<int32_t>(stop), &score_members);
+          ->GetStorage()
+          ->ZRevrange(client->Key(), static_cast<int32_t>(start), static_cast<int32_t>(stop), &score_members);
   if (s.ok() || s.IsNotFound()) {
     if (is_ws) {
       char buf[32];
@@ -189,7 +191,8 @@ void ZRangebyscoreCmd::DoCmd(PClient* client) {
   }
   std::vector<storage::ScoreMember> score_members;
   storage::Status s = PSTORE.GetBackend(client->GetCurrentDB())
-                          ->GetStorage()->ZRangebyscore(client->Key(), min_score, max_score, left_close, right_close, &score_members);
+                          ->GetStorage()
+                          ->ZRangebyscore(client->Key(), min_score, max_score, left_close, right_close, &score_members);
   if (!s.ok() && !s.IsNotFound()) {
     client->SetRes(CmdRes::kErrOther, s.ToString());
     return;
@@ -290,7 +293,8 @@ void ZRevRangeByScoreCmd::DoCmd(PClient* client) {
   }
   std::vector<storage::ScoreMember> score_members;
   storage::Status s = PSTORE.GetBackend(client->GetCurrentDB())
-                          ->GetStorage()->ZRevrangebyscore(client->Key(), min_score, max_score, left_close, right_close, count,
+                          ->GetStorage()
+                          ->ZRevrangebyscore(client->Key(), min_score, max_score, left_close, right_close, count,
                                              offset, &score_members);
   if (!s.ok() && !s.IsNotFound()) {
     client->SetRes(CmdRes::kErrOther, s.ToString());

--- a/src/db.cpp
+++ b/src/db.cpp
@@ -1,0 +1,30 @@
+//
+// Created by dingxiaoshuai on 2024/3/18.
+//
+
+#include "db.h"
+#include "config.h"
+
+extern pikiwidb::PConfig g_config;
+
+namespace pikiwidb {
+
+DB::DB(const int db_id, const std::string &db_path)
+    :db_id_(db_id), db_path_(db_path) {
+  storage::StorageOptions storage_options;
+  storage_options.options.create_if_missing = true;
+  storage_options.db_instance_num = g_config.db_instance_num;
+  storage_options.db_id = db_id;
+
+  // options for CF
+  storage_options.options.ttl = g_config.rocksdb_ttl_second;
+  storage_options.options.periodic_compaction_seconds = g_config.rocksdb_periodic_second;
+
+  PString dbpath = db_path_ + std::to_string(db_id) + '/';
+
+  storage_->Open(storage_options, dbpath);
+  opened_ = true;
+  INFO("Open DB success!");
+  }
+}
+

--- a/src/db.cpp
+++ b/src/db.cpp
@@ -1,6 +1,9 @@
-//
-// Created by dingxiaoshuai on 2024/3/18.
-//
+/*
+ * Copyright (c) 2024-present, Qihoo, Inc.  All rights reserved.
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
 
 #include "db.h"
 #include "config.h"

--- a/src/db.cpp
+++ b/src/db.cpp
@@ -9,8 +9,7 @@ extern pikiwidb::PConfig g_config;
 
 namespace pikiwidb {
 
-DB::DB(const int db_id, const std::string &db_path)
-    :db_id_(db_id), db_path_(db_path) {
+DB::DB(int db_id, const std::string &db_path) : db_id_(db_id), db_path_(db_path + std::to_string(db_id) + '/') {
   storage::StorageOptions storage_options;
   storage_options.options.create_if_missing = true;
   storage_options.db_instance_num = g_config.db_instance_num;
@@ -19,12 +18,12 @@ DB::DB(const int db_id, const std::string &db_path)
   // options for CF
   storage_options.options.ttl = g_config.rocksdb_ttl_second;
   storage_options.options.periodic_compaction_seconds = g_config.rocksdb_periodic_second;
-
-  PString dbpath = db_path_ + std::to_string(db_id) + '/';
-
-  storage_->Open(storage_options, dbpath);
-  opened_ = true;
-  INFO("Open DB success!");
+  storage_ = std::make_unique<storage::Storage>();
+  if (auto s = storage_->Open(storage_options, db_path_); !s.ok()) {
+    ERROR("Storage open failed! {}", s.ToString());
+    abort();
   }
+  opened_ = true;
+  INFO("Open DB{} success!", db_id);
 }
-
+}  // namespace pikiwidb

--- a/src/db.h
+++ b/src/db.h
@@ -1,0 +1,49 @@
+//
+// Created by dingxiaoshuai on 2024/3/18.
+//
+
+#ifndef PIKIWIDB_DB_H
+#define PIKIWIDB_DB_H
+
+#include <string>
+
+#include "pstd/noncopyable.h"
+#include "storage/storage.h"
+#include "log.h"
+
+namespace pikiwidb {
+class DB : public pstd::noncopyable {
+ public:
+  DB(const int db_id, const std::string& db_path);
+  std::unique_ptr<storage::Storage>& GetStorage() { return storage_; }
+
+  std::shared_mutex& GetSharedMutex() { return storage_mutex_; }
+
+ private:
+  const int db_id_;
+  const std::string db_path_;
+
+  /**
+   * If you want to change the pointer that points to storage,
+   * you must first acquire a mutex lock.
+   * If you only want to access the pointer,
+   * you just need to obtain a shared lock.
+   */
+  std::shared_mutex storage_mutex_;
+  bool opened_ = false;
+  std::unique_ptr<storage::Storage> storage_;
+
+  /**
+   * If you want to change the status below，you must first acquire
+   * a mutex lock.
+   * If you only want to access the status below,
+   * you just need to obtain a shared lock.
+   */
+  std::shared_mutex checkpoint_mutex_;
+  bool checkpoint_in_process_ = false;
+  int64_t last_checkpoint_time_ = -1;
+  bool last_checkpoint_success_ = false;
+};
+}
+
+#endif  // PIKIWIDB_DB_H

--- a/src/db.h
+++ b/src/db.h
@@ -1,6 +1,9 @@
-//
-// Created by dingxiaoshuai on 2024/3/18.
-//
+/*
+ * Copyright (c) 2024-present, Qihoo, Inc.  All rights reserved.
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
 
 #ifndef PIKIWIDB_DB_H
 #define PIKIWIDB_DB_H

--- a/src/db.h
+++ b/src/db.h
@@ -7,17 +7,23 @@
 
 #include <string>
 
+#include "log.h"
 #include "pstd/noncopyable.h"
 #include "storage/storage.h"
-#include "log.h"
 
 namespace pikiwidb {
-class DB : public pstd::noncopyable {
+class DB {
  public:
-  DB(const int db_id, const std::string& db_path);
+  DB(int db_id, const std::string& db_path);
   std::unique_ptr<storage::Storage>& GetStorage() { return storage_; }
 
-  std::shared_mutex& GetSharedMutex() { return storage_mutex_; }
+  void Lock() { storage_mutex_.lock(); }
+
+  void UnLock() { storage_mutex_.unlock(); }
+
+  void LockShared() { storage_mutex_.lock_shared(); }
+
+  void UnLockShared() { storage_mutex_.unlock_shared(); }
 
  private:
   const int db_id_;
@@ -30,8 +36,8 @@ class DB : public pstd::noncopyable {
    * you just need to obtain a shared lock.
    */
   std::shared_mutex storage_mutex_;
-  bool opened_ = false;
   std::unique_ptr<storage::Storage> storage_;
+  bool opened_ = false;
 
   /**
    * If you want to change the status below，you must first acquire
@@ -44,6 +50,6 @@ class DB : public pstd::noncopyable {
   int64_t last_checkpoint_time_ = -1;
   bool last_checkpoint_success_ = false;
 };
-}
+}  // namespace pikiwidb
 
 #endif  // PIKIWIDB_DB_H

--- a/src/storage/include/storage/storage.h
+++ b/src/storage/include/storage/storage.h
@@ -54,9 +54,8 @@ struct StorageOptions {
   size_t block_cache_size = 0;
   bool share_block_cache = false;
   size_t statistics_max_size = 0;
-  size_t small_compaction_threshold = 5000;
-  size_t small_compaction_duration_threshold = 10000;
   size_t db_instance_num = 3;  // default = 3
+  int db_id;
   Status ResetOptions(const OptionType& option_type, const std::unordered_map<std::string, std::string>& options_map);
 };
 
@@ -1097,6 +1096,7 @@ class Storage {
   // For scan keys in data base
   std::atomic<bool> scan_keynum_exit_ = false;
   int32_t db_instance_num_;
+  int db_id_;
 };
 
 }  //  namespace storage

--- a/src/storage/include/storage/storage.h
+++ b/src/storage/include/storage/storage.h
@@ -1097,8 +1097,8 @@ class Storage {
 
   // For scan keys in data base
   std::atomic<bool> scan_keynum_exit_ = false;
-  size_t db_instance_num_;
-  int db_id_;
+  size_t db_instance_num_ = 3;
+  int db_id_ = 0;
 };
 
 }  //  namespace storage

--- a/src/storage/include/storage/storage.h
+++ b/src/storage/include/storage/storage.h
@@ -54,6 +54,8 @@ struct StorageOptions {
   size_t block_cache_size = 0;
   bool share_block_cache = false;
   size_t statistics_max_size = 0;
+  size_t small_compaction_threshold = 5000;
+  size_t small_compaction_duration_threshold = 10000;
   size_t db_instance_num = 3;  // default = 3
   int db_id;
   Status ResetOptions(const OptionType& option_type, const std::unordered_map<std::string, std::string>& options_map);
@@ -1095,7 +1097,7 @@ class Storage {
 
   // For scan keys in data base
   std::atomic<bool> scan_keynum_exit_ = false;
-  int32_t db_instance_num_;
+  size_t db_instance_num_;
   int db_id_;
 };
 

--- a/src/storage/src/storage.cc
+++ b/src/storage/src/storage.cc
@@ -91,6 +91,8 @@ Status Storage::Open(const StorageOptions& storage_options, const std::string& d
   }
 
   slot_indexer_ = std::make_unique<SlotIndexer>(db_instance_num_);
+  db_id_ = storage_options.db_id;
+
   is_opened_.store(true);
   return Status::OK();
 }

--- a/src/storage/src/storage.cc
+++ b/src/storage/src/storage.cc
@@ -82,12 +82,14 @@ static std::string AppendSubDirectory(const std::string& db_path, int index) {
 Status Storage::Open(const StorageOptions& storage_options, const std::string& db_path) {
   mkpath(db_path.c_str(), 0755);
   db_instance_num_ = storage_options.db_instance_num;
-  for (int index = 0; index < db_instance_num_; index++) {
+  for (size_t index = 0; index < db_instance_num_; index++) {
     insts_.emplace_back(std::make_unique<Redis>(this, index));
     Status s = insts_.back()->Open(storage_options, AppendSubDirectory(db_path, index));
     if (!s.ok()) {
-      ERROR("open db failed", s.ToString());
+      ERROR("open RocksDB{} failed {}", index, s.ToString());
+      return Status::IOError();
     }
+    INFO("open RocksDB{} success!", index);
   }
 
   slot_indexer_ = std::make_unique<SlotIndexer>(db_instance_num_);

--- a/src/store.cc
+++ b/src/store.cc
@@ -12,6 +12,8 @@
 #include "config.h"
 #include "log.h"
 #include "multi.h"
+#include "db.h"
+
 namespace pikiwidb {
 
 PStore& PStore::Instance() {
@@ -24,32 +26,14 @@ void PStore::Init(int dbNum) {
     return;
   }
 
-  backends_.resize(dbNum);
+  backends_.reserve(dbNum);
 
   if (g_config.backend == kBackEndRocksDB) {
-    for (size_t i = 0; i < dbNum; ++i) {
-      std::unique_ptr<storage::Storage> db = std::make_unique<storage::Storage>();
-      storage::StorageOptions storage_options;
-      storage_options.options.create_if_missing = true;
-      storage_options.db_instance_num = g_config.db_instance_num;
-
-      // options for CF
-      storage_options.options.ttl = g_config.rocksdb_ttl_second;
-      storage_options.options.periodic_compaction_seconds = g_config.rocksdb_periodic_second;
-
-      PString dbpath = g_config.dbpath + std::to_string(i) + '/';
-
-      storage::Status s = db->Open(storage_options, dbpath.data());
-      if (!s.ok()) {
-        assert(false);
-      } else {
-        INFO("Open RocksDB {} success", dbpath);
-      }
-
-      backends_[i] = std::move(db);
+    for (int i= 0; i < dbNum; i++) {
+      backends_.push_back(std::make_unique<DB>(i, g_config.dbpath));
     }
   } else {
-    // ERROR: unsupport backend
+    ERROR("unsupport backend!");
     return;
   }
 }

--- a/src/store.cc
+++ b/src/store.cc
@@ -5,14 +5,12 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
-#include "store.h"
-#include <cassert>
-#include <limits>
 #include <string>
+
 #include "config.h"
-#include "log.h"
-#include "multi.h"
 #include "db.h"
+#include "log.h"
+#include "store.h"
 
 namespace pikiwidb {
 
@@ -29,12 +27,12 @@ void PStore::Init(int dbNum) {
   backends_.reserve(dbNum);
 
   if (g_config.backend == kBackEndRocksDB) {
-    for (int i= 0; i < dbNum; i++) {
-      backends_.push_back(std::make_unique<DB>(i, g_config.dbpath));
+    for (int i = 0; i < dbNum; i++) {
+      auto db = std::make_unique<DB>(i, g_config.dbpath);
+      backends_.push_back(std::move(db));
     }
   } else {
     ERROR("unsupport backend!");
-    return;
   }
 }
 

--- a/src/store.h
+++ b/src/store.h
@@ -11,6 +11,7 @@
 
 #include "common.h"
 #include "storage/storage.h"
+#include "db.h"
 
 #include <map>
 #include <memory>
@@ -29,12 +30,12 @@ class PStore {
 
   void Init(int dbNum);
 
-  std::unique_ptr<storage::Storage>& GetBackend(int32_t index) { return backends_[index]; };
+  std::unique_ptr<DB>& GetBackend(int32_t index) { return backends_[index]; };
 
  private:
   PStore() = default;
 
-  std::vector<std::unique_ptr<storage::Storage>> backends_;
+  std::vector<std::unique_ptr<DB>> backends_;
 };
 
 #define PSTORE PStore::Instance()

--- a/src/store.h
+++ b/src/store.h
@@ -10,8 +10,8 @@
 #define GLOG_NO_ABBREVIATED_SEVERITIES
 
 #include "common.h"
-#include "storage/storage.h"
 #include "db.h"
+#include "storage/storage.h"
 
 #include <map>
 #include <memory>

--- a/src/store.h
+++ b/src/store.h
@@ -32,9 +32,17 @@ class PStore {
 
   std::unique_ptr<DB>& GetBackend(int32_t index) { return backends_[index]; };
 
+  std::shared_mutex& SharedMutex() { return dbs_mutex_; }
+
  private:
   PStore() = default;
 
+  /**
+   * If you want to access all the DBs at the same time,
+   * then you must hold the lock.
+   * For example: you want to execute flushall or bgsave.
+   */
+  std::shared_mutex dbs_mutex_;
   std::vector<std::unique_ptr<DB>> backends_;
 };
 


### PR DESCRIPTION
现在，Storage 的访问无需任何锁，如果都是不涉及 Storage 指针的更改，那么不会存在问题，但是如果有类似于 flushDB 的命令会修改 Storage 的指针，就会在并发的情况下引起空指针问题。针对这种大量读非常小写的情况下，使用一把读写锁来保护 storage 。
所以增加了 DB 类封装了 Storage 类，里面有一把 sharedLock 来保护 Storage ，如果是类似于 flushdb 的操作，上写锁，否则上读锁，如何判断需要对相应的 cmd 加上 flag 。
加锁的位置在 cmd 的 execute 函数中，在进入 do 之前完成上锁。