### PR TITLE
feat: floyd supports one key for one data structure

### DIFF
--- a/src/client.cc
+++ b/src/client.cc
@@ -130,6 +130,9 @@ void CmdRes::SetRes(CmdRes::CmdRet _ret, const std::string& content) {
     case kInvalidCursor:
       AppendStringRaw("-ERR invalid cursor");
       break;
+    case kmultikey:
+      AppendStringRaw("-ERR WRONGTYPE Operation against a key holding the wrong kind of value");
+      break;
     default:
       break;
   }

--- a/src/client.h
+++ b/src/client.h
@@ -48,6 +48,7 @@ class CmdRes {
     kErrOther,
     KIncrByOverFlow,
     kInvalidCursor,
+    kmultikey,
   };
 
   CmdRes() = default;

--- a/src/storage/include/storage/storage_define.h
+++ b/src/storage/include/storage/storage_define.h
@@ -33,15 +33,16 @@ const int kTimestampLength = 8;
 
 enum ColumnFamilyIndex {
   kStringsCF = 0,
-  kHashesMetaCF = 1,
-  kHashesDataCF = 2,
-  kSetsMetaCF = 3,
-  kSetsDataCF = 4,
-  kListsMetaCF = 5,
-  kListsDataCF = 6,
-  kZsetsMetaCF = 7,
-  kZsetsDataCF = 8,
-  kZsetsScoreCF = 9,
+ // kHashesMetaCF = 1,
+  kHashesDataCF = 1,
+ // kSetsMetaCF = 3,
+  kSetsDataCF = 2,
+//  kListsMetaCF = 5,
+  kListsDataCF = 3,
+//  kZsetsMetaCF = 7,
+  kZsetsDataCF = 4,
+  kZsetsScoreCF = 5,
+  kMetaCF = 6,
 };
 
 const static char kNeedTransformCharacter = '\u0000';

--- a/src/storage/src/base_filter.h
+++ b/src/storage/src/base_filter.h
@@ -165,6 +165,6 @@ using ZSetsMetaFilter = BaseMetaFilter;
 using ZSetsMetaFilterFactory = BaseMetaFilterFactory;
 using ZSetsDataFilter = BaseDataFilter;
 using ZSetsDataFilterFactory = BaseDataFilterFactory;
-
+using MetaFilterFactory = BaseMetaFilterFactory;
 }  //  namespace storage
 #endif  // SRC_BASE_FILTER_H_

--- a/src/storage/src/base_meta_value_format.h
+++ b/src/storage/src/base_meta_value_format.h
@@ -10,6 +10,7 @@
 
 #include "src/base_value_format.h"
 #include "storage/storage_define.h"
+#include "pstd/log.h"
 
 namespace storage {
 
@@ -59,17 +60,26 @@ class ParsedBaseMetaValue : public ParsedInternalValue {
   explicit ParsedBaseMetaValue(std::string* internal_value_str) : ParsedInternalValue(internal_value_str) {
     if (internal_value_str->size() >= kBaseMetaValueSuffixLength) {
       int offset = 0;
-      user_value_ = Slice(internal_value_str->data(), internal_value_str->size() - kBaseMetaValueSuffixLength);
+      type_ = Slice(internal_value_str->data(), 1);
+      offset += 1;
+      //std::cout << "type: " << type_.ToStringView() << std::endl;
+      user_value_ = Slice(internal_value_str->data() + 1, internal_value_str->size() - kBaseMetaValueSuffixLength - 1);
+     // std::cout << "user_value: " << user_value_.ToStringView() << std::endl;
+     // std::cout << "user_value_size: " << user_value_.size() << std::endl;
       offset += user_value_.size();
       version_ = DecodeFixed64(internal_value_str->data() + offset);
+     // std::cout << "version:" << version_ << std::endl;
       offset += sizeof(version_);
       memcpy(reserve_, internal_value_str->data() + offset, sizeof(reserve_));
       offset += sizeof(reserve_);
       ctime_ = DecodeFixed64(internal_value_str->data() + offset);
+      //std::cout << "ctime: " << ctime_ << std::endl;
       offset += sizeof(ctime_);
       etime_ = DecodeFixed64(internal_value_str->data() + offset);
+      //std::cout << "etime: " << etime_ << std::endl;
     }
-    count_ = DecodeFixed32(internal_value_str->data());
+    count_ = DecodeFixed32(internal_value_str->data() + 1);
+    //std::cout << "count: " << count_ << std::endl;
   }
 
   // Use this constructor in rocksdb::CompactionFilter::Filter();
@@ -134,11 +144,15 @@ class ParsedBaseMetaValue : public ParsedInternalValue {
 
   int32_t Count() { return count_; }
 
+  bool IsType(Slice c) {
+    return type_.ToStringView() == c.ToStringView();
+  }
+
   void SetCount(int32_t count) {
     count_ = count;
     if (value_) {
       char* dst = const_cast<char*>(value_->data());
-      EncodeFixed32(dst, count_);
+      EncodeFixed32(dst + 1, count_);
     }
   }
 
@@ -155,7 +169,7 @@ class ParsedBaseMetaValue : public ParsedInternalValue {
     count_ += delta;
     if (value_) {
       char* dst = const_cast<char*>(value_->data());
-      EncodeFixed32(dst, count_);
+      EncodeFixed32(dst + 1, count_);
     }
   }
 

--- a/src/storage/src/base_value_format.h
+++ b/src/storage/src/base_value_format.h
@@ -130,6 +130,7 @@ class ParsedInternalValue {
   virtual void SetEtimeToValue() = 0;
   virtual void SetCtimeToValue() = 0;
   std::string* value_ = nullptr;
+  Slice type_;
   Slice user_value_;
   uint64_t version_ = 0;
   uint64_t ctime_ = 0;

--- a/src/storage/src/coding.h
+++ b/src/storage/src/coding.h
@@ -26,6 +26,15 @@ namespace storage {
 static const bool kLittleEndian = STORAGE_PLATFORM_IS_LITTLE_ENDIAN;
 #undef STORAGE_PLATFORM_IS_LITTLE_ENDIAN
 
+inline void EncodeFixed8(char* buf, char type) {
+  if (kLittleEndian) {
+      memcpy(buf, &type, sizeof(type));
+  } else {
+    uint8_t converted_value = static_cast<uint8_t>(type);
+    buf[0] = converted_value;
+  }
+}
+
 inline void EncodeFixed32(char* buf, uint32_t value) {
   if (kLittleEndian) {
     memcpy(buf, &value, sizeof(value));

--- a/src/storage/src/redis.cc
+++ b/src/storage/src/redis.cc
@@ -60,7 +60,8 @@ Status Redis::Open(const StorageOptions& storage_options, const std::string& db_
 
   rocksdb::DBOptions db_ops(storage_options.options);
   db_ops.create_missing_column_families = true;
-
+  rocksdb::ColumnFamilyOptions meta_cf_ops(storage_options.options);
+  rocksdb::BlockBasedTableOptions meta_cf_table_ops(table_ops);
   // string column-family options
   rocksdb::ColumnFamilyOptions string_cf_ops(storage_options.options);
   string_cf_ops.compaction_filter_factory = std::make_shared<StringsFilterFactory>();
@@ -71,86 +72,76 @@ Status Redis::Open(const StorageOptions& storage_options, const std::string& db_
   string_cf_ops.table_factory.reset(rocksdb::NewBlockBasedTableFactory(string_table_ops));
 
   // hash column-family options
-  rocksdb::ColumnFamilyOptions hash_meta_cf_ops(storage_options.options);
   rocksdb::ColumnFamilyOptions hash_data_cf_ops(storage_options.options);
-  hash_meta_cf_ops.compaction_filter_factory = std::make_shared<HashesMetaFilterFactory>();
+  meta_cf_ops.compaction_filter_factory = std::make_shared<HashesMetaFilterFactory>();
   hash_data_cf_ops.compaction_filter_factory =
-      std::make_shared<HashesDataFilterFactory>(&db_, &handles_, kHashesMetaCF);
-  rocksdb::BlockBasedTableOptions hash_meta_cf_table_ops(table_ops);
+      std::make_shared<HashesDataFilterFactory>(&db_, &handles_, kMetaCF);
   rocksdb::BlockBasedTableOptions hash_data_cf_table_ops(table_ops);
   if (!storage_options.share_block_cache && (storage_options.block_cache_size > 0)) {
-    hash_meta_cf_table_ops.block_cache = rocksdb::NewLRUCache(storage_options.block_cache_size);
+    meta_cf_table_ops.block_cache = rocksdb::NewLRUCache(storage_options.block_cache_size);
     hash_data_cf_table_ops.block_cache = rocksdb::NewLRUCache(storage_options.block_cache_size);
   }
-  hash_meta_cf_ops.table_factory.reset(rocksdb::NewBlockBasedTableFactory(hash_meta_cf_table_ops));
+  meta_cf_ops.table_factory.reset(rocksdb::NewBlockBasedTableFactory(meta_cf_table_ops));
   hash_data_cf_ops.table_factory.reset(rocksdb::NewBlockBasedTableFactory(hash_data_cf_table_ops));
 
   // list column-family options
-  rocksdb::ColumnFamilyOptions list_meta_cf_ops(storage_options.options);
   rocksdb::ColumnFamilyOptions list_data_cf_ops(storage_options.options);
-  list_meta_cf_ops.compaction_filter_factory = std::make_shared<ListsMetaFilterFactory>();
-  list_data_cf_ops.compaction_filter_factory = std::make_shared<ListsDataFilterFactory>(&db_, &handles_, kListsMetaCF);
+  meta_cf_ops.compaction_filter_factory = std::make_shared<ListsMetaFilterFactory>();
+  list_data_cf_ops.compaction_filter_factory = std::make_shared<ListsDataFilterFactory>(&db_, &handles_, kMetaCF);
   list_data_cf_ops.comparator = ListsDataKeyComparator();
-  rocksdb::BlockBasedTableOptions list_meta_cf_table_ops(table_ops);
   rocksdb::BlockBasedTableOptions list_data_cf_table_ops(table_ops);
   if (!storage_options.share_block_cache && (storage_options.block_cache_size > 0)) {
-    list_meta_cf_table_ops.block_cache = rocksdb::NewLRUCache(storage_options.block_cache_size);
+    meta_cf_table_ops.block_cache = rocksdb::NewLRUCache(storage_options.block_cache_size);
     list_data_cf_table_ops.block_cache = rocksdb::NewLRUCache(storage_options.block_cache_size);
   }
-  list_meta_cf_ops.table_factory.reset(rocksdb::NewBlockBasedTableFactory(list_meta_cf_table_ops));
+  meta_cf_ops.table_factory.reset(rocksdb::NewBlockBasedTableFactory(meta_cf_table_ops));
   list_data_cf_ops.table_factory.reset(rocksdb::NewBlockBasedTableFactory(list_data_cf_table_ops));
 
   // set column-family options
-  rocksdb::ColumnFamilyOptions set_meta_cf_ops(storage_options.options);
   rocksdb::ColumnFamilyOptions set_data_cf_ops(storage_options.options);
-  set_meta_cf_ops.compaction_filter_factory = std::make_shared<SetsMetaFilterFactory>();
-  set_data_cf_ops.compaction_filter_factory = std::make_shared<SetsMemberFilterFactory>(&db_, &handles_, kSetsMetaCF);
-  rocksdb::BlockBasedTableOptions set_meta_cf_table_ops(table_ops);
+  meta_cf_ops.compaction_filter_factory = std::make_shared<SetsMetaFilterFactory>();
+  set_data_cf_ops.compaction_filter_factory = std::make_shared<SetsMemberFilterFactory>(&db_, &handles_, kMetaCF);
   rocksdb::BlockBasedTableOptions set_data_cf_table_ops(table_ops);
   if (!storage_options.share_block_cache && (storage_options.block_cache_size > 0)) {
-    set_meta_cf_table_ops.block_cache = rocksdb::NewLRUCache(storage_options.block_cache_size);
+    meta_cf_table_ops.block_cache = rocksdb::NewLRUCache(storage_options.block_cache_size);
     set_data_cf_table_ops.block_cache = rocksdb::NewLRUCache(storage_options.block_cache_size);
   }
-  set_meta_cf_ops.table_factory.reset(rocksdb::NewBlockBasedTableFactory(set_meta_cf_table_ops));
+  meta_cf_ops.table_factory.reset(rocksdb::NewBlockBasedTableFactory(meta_cf_table_ops));
   set_data_cf_ops.table_factory.reset(rocksdb::NewBlockBasedTableFactory(set_data_cf_table_ops));
 
   // zset column-family options
-  rocksdb::ColumnFamilyOptions zset_meta_cf_ops(storage_options.options);
   rocksdb::ColumnFamilyOptions zset_data_cf_ops(storage_options.options);
   rocksdb::ColumnFamilyOptions zset_score_cf_ops(storage_options.options);
-  zset_meta_cf_ops.compaction_filter_factory = std::make_shared<ZSetsMetaFilterFactory>();
-  zset_data_cf_ops.compaction_filter_factory = std::make_shared<ZSetsDataFilterFactory>(&db_, &handles_, kZsetsMetaCF);
+  meta_cf_ops.compaction_filter_factory = std::make_shared<ZSetsMetaFilterFactory>();
+  zset_data_cf_ops.compaction_filter_factory = std::make_shared<ZSetsDataFilterFactory>(&db_, &handles_, kMetaCF);
   zset_score_cf_ops.compaction_filter_factory =
-      std::make_shared<ZSetsScoreFilterFactory>(&db_, &handles_, kZsetsMetaCF);
+      std::make_shared<ZSetsScoreFilterFactory>(&db_, &handles_, kMetaCF);
   zset_score_cf_ops.comparator = ZSetsScoreKeyComparator();
 
-  rocksdb::BlockBasedTableOptions zset_meta_cf_table_ops(table_ops);
   rocksdb::BlockBasedTableOptions zset_data_cf_table_ops(table_ops);
   rocksdb::BlockBasedTableOptions zset_score_cf_table_ops(table_ops);
   if (!storage_options.share_block_cache && (storage_options.block_cache_size > 0)) {
-    zset_meta_cf_table_ops.block_cache = rocksdb::NewLRUCache(storage_options.block_cache_size);
+    meta_cf_table_ops.block_cache = rocksdb::NewLRUCache(storage_options.block_cache_size);
     zset_data_cf_table_ops.block_cache = rocksdb::NewLRUCache(storage_options.block_cache_size);
-    zset_meta_cf_table_ops.block_cache = rocksdb::NewLRUCache(storage_options.block_cache_size);
+    meta_cf_table_ops.block_cache = rocksdb::NewLRUCache(storage_options.block_cache_size);
   }
-  zset_meta_cf_ops.table_factory.reset(rocksdb::NewBlockBasedTableFactory(zset_meta_cf_table_ops));
+  meta_cf_ops.table_factory.reset(rocksdb::NewBlockBasedTableFactory(meta_cf_table_ops));
   zset_data_cf_ops.table_factory.reset(rocksdb::NewBlockBasedTableFactory(zset_data_cf_table_ops));
   zset_score_cf_ops.table_factory.reset(rocksdb::NewBlockBasedTableFactory(zset_score_cf_table_ops));
 
   std::vector<rocksdb::ColumnFamilyDescriptor> column_families;
   column_families.emplace_back(rocksdb::kDefaultColumnFamilyName, string_cf_ops);
   // hash CF
-  column_families.emplace_back("hash_meta_cf", hash_meta_cf_ops);
   column_families.emplace_back("hash_data_cf", hash_data_cf_ops);
   // set CF
-  column_families.emplace_back("set_meta_cf", set_meta_cf_ops);
   column_families.emplace_back("set_data_cf", set_data_cf_ops);
   // list CF
-  column_families.emplace_back("list_meta_cf", list_meta_cf_ops);
   column_families.emplace_back("list_data_cf", list_data_cf_ops);
   // zset CF
-  column_families.emplace_back("zset_meta_cf", zset_meta_cf_ops);
   column_families.emplace_back("zset_data_cf", zset_data_cf_ops);
   column_families.emplace_back("zset_score_cf", zset_score_cf_ops);
+  // meta CF
+  column_families.emplace_back("meta_cf", meta_cf_ops);
   return rocksdb::DB::Open(db_ops, db_path, column_families, &handles_, &db_);
 }
 
@@ -194,7 +185,7 @@ Status Redis::CompactRange(const DataType& dtype, const rocksdb::Slice* begin, c
       break;
     case DataType::kHashes:
       if (type == kMeta || type == kMetaAndData) {
-        s = db_->CompactRange(default_compact_range_options_, handles_[kHashesMetaCF], begin, end);
+        s = db_->CompactRange(default_compact_range_options_, handles_[kMetaCF], begin, end);
       }
       if (s.ok() && (type == kData || type == kMetaAndData)) {
         s = db_->CompactRange(default_compact_range_options_, handles_[kHashesDataCF], begin, end);
@@ -202,7 +193,7 @@ Status Redis::CompactRange(const DataType& dtype, const rocksdb::Slice* begin, c
       break;
     case DataType::kSets:
       if (type == kMeta || type == kMetaAndData) {
-        db_->CompactRange(default_compact_range_options_, handles_[kSetsMetaCF], begin, end);
+        db_->CompactRange(default_compact_range_options_, handles_[kMetaCF], begin, end);
       }
       if (s.ok() && (type == kData || type == kMetaAndData)) {
         db_->CompactRange(default_compact_range_options_, handles_[kSetsDataCF], begin, end);
@@ -210,7 +201,7 @@ Status Redis::CompactRange(const DataType& dtype, const rocksdb::Slice* begin, c
       break;
     case DataType::kLists:
       if (type == kMeta || type == kMetaAndData) {
-        s = db_->CompactRange(default_compact_range_options_, handles_[kListsMetaCF], begin, end);
+        s = db_->CompactRange(default_compact_range_options_, handles_[kMetaCF], begin, end);
       }
       if (s.ok() && (type == kData || type == kMetaAndData)) {
         s = db_->CompactRange(default_compact_range_options_, handles_[kListsDataCF], begin, end);
@@ -218,7 +209,7 @@ Status Redis::CompactRange(const DataType& dtype, const rocksdb::Slice* begin, c
       break;
     case DataType::kZSets:
       if (type == kMeta || type == kMetaAndData) {
-        db_->CompactRange(default_compact_range_options_, handles_[kZsetsMetaCF], begin, end);
+        db_->CompactRange(default_compact_range_options_, handles_[kMetaCF], begin, end);
       }
       if (s.ok() && (type == kData || type == kMetaAndData)) {
         db_->CompactRange(default_compact_range_options_, handles_[kZsetsDataCF], begin, end);

--- a/src/storage/src/redis.h
+++ b/src/storage/src/redis.h
@@ -308,19 +308,19 @@ class Redis {
     options.iterate_upper_bound = upper_bound;
     switch (type) {
       case 'k':
-        return new StringsIterator(options, db_, handles_[kStringsCF], pattern);
+        return new StringsIterator(options, db_, handles_[kMetaCF], pattern);
         break;
       case 'h':
-        return new HashesIterator(options, db_, handles_[kHashesMetaCF], pattern);
+        return new HashesIterator(options, db_, handles_[kMetaCF], pattern);
         break;
       case 's':
-        return new SetsIterator(options, db_, handles_[kSetsMetaCF], pattern);
+        return new SetsIterator(options, db_, handles_[kMetaCF], pattern);
         break;
       case 'l':
-        return new ListsIterator(options, db_, handles_[kListsMetaCF], pattern);
+        return new ListsIterator(options, db_, handles_[kMetaCF], pattern);
         break;
       case 'z':
-        return new ZsetsIterator(options, db_, handles_[kZsetsMetaCF], pattern);
+        return new ZsetsIterator(options, db_, handles_[kMetaCF], pattern);
         break;
       default:
         WARN("Invalid datatype to create iterator");

--- a/src/storage/src/redis_hashes.cc
+++ b/src/storage/src/redis_hashes.cc
@@ -21,6 +21,8 @@
 #include "storage/storage_define.h"
 #include "storage/util.h"
 
+rocksdb::Slice HashType("h");
+
 namespace storage {
 Status Redis::ScanHashesKeyNum(KeyInfo* key_info) {
   uint64_t keys = 0;
@@ -37,7 +39,7 @@ Status Redis::ScanHashesKeyNum(KeyInfo* key_info) {
   int64_t curtime;
   rocksdb::Env::Default()->GetCurrentTime(&curtime);
 
-  rocksdb::Iterator* iter = db_->NewIterator(iterator_options, handles_[kHashesMetaCF]);
+  rocksdb::Iterator* iter = db_->NewIterator(iterator_options, handles_[kMetaCF]);
   for (iter->SeekToFirst(); iter->Valid(); iter->Next()) {
     ParsedHashesMetaValue parsed_hashes_meta_value(iter->value());
     if (parsed_hashes_meta_value.IsStale() || parsed_hashes_meta_value.Count() == 0) {
@@ -71,7 +73,7 @@ Status Redis::HashesPKPatternMatchDel(const std::string& pattern, int32_t* ret) 
   int32_t total_delete = 0;
   Status s;
   rocksdb::WriteBatch batch;
-  rocksdb::Iterator* iter = db_->NewIterator(iterator_options, handles_[kHashesMetaCF]);
+  rocksdb::Iterator* iter = db_->NewIterator(iterator_options, handles_[kMetaCF]);
   iter->SeekToFirst();
   while (iter->Valid()) {
     key = iter->key().ToString();
@@ -80,7 +82,7 @@ Status Redis::HashesPKPatternMatchDel(const std::string& pattern, int32_t* ret) 
     if (!parsed_hashes_meta_value.IsStale() && (parsed_hashes_meta_value.Count() != 0) &&
         (StringMatch(pattern.data(), pattern.size(), key.data(), key.size(), 0) != 0)) {
       parsed_hashes_meta_value.InitialMetaValue();
-      batch.Put(handles_[kHashesMetaCF], key, meta_value);
+      batch.Put(handles_[kMetaCF], key, meta_value);
     }
     if (static_cast<size_t>(batch.Count()) >= BATCH_DELETE_LIMIT) {
       s = db_->Write(default_write_options_, &batch);
@@ -130,7 +132,7 @@ Status Redis::HDel(const Slice& key, const std::vector<std::string>& fields, int
   read_options.snapshot = snapshot;
 
   BaseMetaKey base_meta_key(key);
-  Status s = db_->Get(read_options, handles_[kHashesMetaCF], base_meta_key.Encode(), &meta_value);
+  Status s = db_->Get(read_options, handles_[kMetaCF], base_meta_key.Encode(), &meta_value);
   if (s.ok()) {
     ParsedHashesMetaValue parsed_hashes_meta_value(&meta_value);
     if (parsed_hashes_meta_value.IsStale() || parsed_hashes_meta_value.Count() == 0) {
@@ -157,7 +159,7 @@ Status Redis::HDel(const Slice& key, const std::vector<std::string>& fields, int
         return Status::InvalidArgument("hash size overflow");
       }
       parsed_hashes_meta_value.ModifyCount(-del_cnt);
-      batch.Put(handles_[kHashesMetaCF], base_meta_key.Encode(), meta_value);
+      batch.Put(handles_[kMetaCF], base_meta_key.Encode(), meta_value);
     }
   } else if (s.IsNotFound()) {
     *ret = 0;
@@ -184,7 +186,7 @@ Status Redis::HGet(const Slice& key, const Slice& field, std::string* value) {
   read_options.snapshot = snapshot;
 
   BaseMetaKey base_meta_key(key);
-  Status s = db_->Get(read_options, handles_[kHashesMetaCF], base_meta_key.Encode(), &meta_value);
+  Status s = db_->Get(read_options, handles_[kMetaCF], base_meta_key.Encode(), &meta_value);
   if (s.ok()) {
     ParsedHashesMetaValue parsed_hashes_meta_value(&meta_value);
     if (parsed_hashes_meta_value.IsStale()) {
@@ -214,7 +216,7 @@ Status Redis::HGetall(const Slice& key, std::vector<FieldValue>* fvs) {
   read_options.snapshot = snapshot;
 
   BaseMetaKey base_meta_key(key);
-  Status s = db_->Get(read_options, handles_[kHashesMetaCF], base_meta_key.Encode(), &meta_value);
+  Status s = db_->Get(read_options, handles_[kMetaCF], base_meta_key.Encode(), &meta_value);
   if (s.ok()) {
     ParsedHashesMetaValue parsed_hashes_meta_value(&meta_value);
     if (parsed_hashes_meta_value.IsStale()) {
@@ -247,7 +249,7 @@ Status Redis::HGetallWithTTL(const Slice& key, std::vector<FieldValue>* fvs, uin
   ScopeSnapshot ss(db_, &snapshot);
   read_options.snapshot = snapshot;
   BaseMetaKey base_meta_key(key);
-  Status s = db_->Get(read_options, handles_[kHashesMetaCF], base_meta_key.Encode(), &meta_value);
+  Status s = db_->Get(read_options, handles_[kMetaCF], base_meta_key.Encode(), &meta_value);
   if (s.ok()) {
     ParsedHashesMetaValue parsed_hashes_meta_value(&meta_value);
     if (parsed_hashes_meta_value.Count() == 0) {
@@ -292,7 +294,7 @@ Status Redis::HIncrby(const Slice& key, const Slice& field, int64_t value, int64
   std::string meta_value;
 
   BaseMetaKey base_meta_key(key);
-  Status s = db_->Get(default_read_options_, handles_[kHashesMetaCF], base_meta_key.Encode(), &meta_value);
+  Status s = db_->Get(default_read_options_, handles_[kMetaCF], base_meta_key.Encode(), &meta_value);
   char value_buf[32] = {0};
   char meta_value_buf[4] = {0};
   if (s.ok()) {
@@ -301,7 +303,7 @@ Status Redis::HIncrby(const Slice& key, const Slice& field, int64_t value, int64
       version = parsed_hashes_meta_value.UpdateVersion();
       parsed_hashes_meta_value.SetCount(1);
       parsed_hashes_meta_value.SetEtime(0);
-      batch.Put(handles_[kHashesMetaCF], base_meta_key.Encode(), meta_value);
+      batch.Put(handles_[kMetaCF], base_meta_key.Encode(), meta_value);
       HashesDataKey hashes_data_key(key, version, field);
       Int64ToStr(value_buf, 32, value);
       batch.Put(handles_[kHashesDataCF], hashes_data_key.Encode(), value_buf);
@@ -332,7 +334,7 @@ Status Redis::HIncrby(const Slice& key, const Slice& field, int64_t value, int64
         }
         BaseDataValue internal_value(value_buf);
         parsed_hashes_meta_value.ModifyCount(1);
-        batch.Put(handles_[kHashesMetaCF], base_meta_key.Encode(), meta_value);
+        batch.Put(handles_[kMetaCF], base_meta_key.Encode(), meta_value);
         batch.Put(handles_[kHashesDataCF], hashes_data_key.Encode(), internal_value.Encode());
         *ret = value;
       } else {
@@ -343,7 +345,7 @@ Status Redis::HIncrby(const Slice& key, const Slice& field, int64_t value, int64
     EncodeFixed32(meta_value_buf, 1);
     HashesMetaValue hashes_meta_value(Slice(meta_value_buf, sizeof(int32_t)));
     version = hashes_meta_value.UpdateVersion();
-    batch.Put(handles_[kHashesMetaCF], base_meta_key.Encode(), hashes_meta_value.Encode());
+    batch.Put(handles_[kMetaCF], base_meta_key.Encode(), hashes_meta_value.Encode());
     HashesDataKey hashes_data_key(key, version, field);
 
     Int64ToStr(value_buf, 32, value);
@@ -374,7 +376,7 @@ Status Redis::HIncrbyfloat(const Slice& key, const Slice& field, const Slice& by
   }
 
   BaseMetaKey base_meta_key(key);
-  Status s = db_->Get(default_read_options_, handles_[kHashesMetaCF], base_meta_key.Encode(), &meta_value);
+  Status s = db_->Get(default_read_options_, handles_[kMetaCF], base_meta_key.Encode(), &meta_value);
   char meta_value_buf[4] = {0};
   if (s.ok()) {
     ParsedHashesMetaValue parsed_hashes_meta_value(&meta_value);
@@ -382,7 +384,7 @@ Status Redis::HIncrbyfloat(const Slice& key, const Slice& field, const Slice& by
       version = parsed_hashes_meta_value.UpdateVersion();
       parsed_hashes_meta_value.SetCount(1);
       parsed_hashes_meta_value.SetEtime(0);
-      batch.Put(handles_[kHashesMetaCF], base_meta_key.Encode(), meta_value);
+      batch.Put(handles_[kMetaCF], base_meta_key.Encode(), meta_value);
       HashesDataKey hashes_data_key(key, version, field);
 
       LongDoubleToStr(long_double_by, new_value);
@@ -415,7 +417,7 @@ Status Redis::HIncrbyfloat(const Slice& key, const Slice& field, const Slice& by
         }
         parsed_hashes_meta_value.ModifyCount(1);
         BaseDataValue internal_value(*new_value);
-        batch.Put(handles_[kHashesMetaCF], base_meta_key.Encode(), meta_value);
+        batch.Put(handles_[kMetaCF], base_meta_key.Encode(), meta_value);
         batch.Put(handles_[kHashesDataCF], hashes_data_key.Encode(), internal_value.Encode());
       } else {
         return s;
@@ -425,7 +427,7 @@ Status Redis::HIncrbyfloat(const Slice& key, const Slice& field, const Slice& by
     EncodeFixed32(meta_value_buf, 1);
     HashesMetaValue hashes_meta_value(Slice(meta_value_buf, sizeof(int32_t)));
     version = hashes_meta_value.UpdateVersion();
-    batch.Put(handles_[kHashesMetaCF], base_meta_key.Encode(), hashes_meta_value.Encode());
+    batch.Put(handles_[kMetaCF], base_meta_key.Encode(), hashes_meta_value.Encode());
 
     HashesDataKey hashes_data_key(key, version, field);
     LongDoubleToStr(long_double_by, new_value);
@@ -449,7 +451,7 @@ Status Redis::HKeys(const Slice& key, std::vector<std::string>* fields) {
   read_options.snapshot = snapshot;
 
   BaseMetaKey base_meta_key(key);
-  Status s = db_->Get(read_options, handles_[kHashesMetaCF], base_meta_key.Encode(), &meta_value);
+  Status s = db_->Get(read_options, handles_[kMetaCF], base_meta_key.Encode(), &meta_value);
   if (s.ok()) {
     ParsedHashesMetaValue parsed_hashes_meta_value(&meta_value);
     if (parsed_hashes_meta_value.IsStale()) {
@@ -477,7 +479,7 @@ Status Redis::HLen(const Slice& key, int32_t* ret) {
   std::string meta_value;
 
   BaseMetaKey base_meta_key(key);
-  Status s = db_->Get(default_read_options_, handles_[kHashesMetaCF], base_meta_key.Encode(), &meta_value);
+  Status s = db_->Get(default_read_options_, handles_[kMetaCF], base_meta_key.Encode(), &meta_value);
   if (s.ok()) {
     ParsedHashesMetaValue parsed_hashes_meta_value(&meta_value);
     if (parsed_hashes_meta_value.IsStale()) {
@@ -506,7 +508,7 @@ Status Redis::HMGet(const Slice& key, const std::vector<std::string>& fields, st
   ScopeSnapshot ss(db_, &snapshot);
   read_options.snapshot = snapshot;
   BaseMetaKey base_meta_key(key);
-  Status s = db_->Get(read_options, handles_[kHashesMetaCF], base_meta_key.Encode(), &meta_value);
+  Status s = db_->Get(read_options, handles_[kMetaCF], base_meta_key.Encode(), &meta_value);
   if (s.ok()) {
     ParsedHashesMetaValue parsed_hashes_meta_value(&meta_value);
     if ((is_stale = parsed_hashes_meta_value.IsStale()) || parsed_hashes_meta_value.Count() == 0) {
@@ -559,7 +561,7 @@ Status Redis::HMSet(const Slice& key, const std::vector<FieldValue>& fvs) {
   std::string meta_value;
 
   BaseMetaKey base_meta_key(key);
-  Status s = db_->Get(default_read_options_, handles_[kHashesMetaCF], base_meta_key.Encode(), &meta_value);
+  Status s = db_->Get(default_read_options_, handles_[kMetaCF], base_meta_key.Encode(), &meta_value);
   char meta_value_buf[4] = {0};
   if (s.ok()) {
     ParsedHashesMetaValue parsed_hashes_meta_value(&meta_value);
@@ -569,7 +571,7 @@ Status Redis::HMSet(const Slice& key, const std::vector<FieldValue>& fvs) {
         return Status::InvalidArgument("hash size overflow");
       }
       parsed_hashes_meta_value.SetCount(static_cast<int32_t>(filtered_fvs.size()));
-      batch.Put(handles_[kHashesMetaCF], base_meta_key.Encode(), meta_value);
+      batch.Put(handles_[kMetaCF], base_meta_key.Encode(), meta_value);
       for (const auto& fv : filtered_fvs) {
         HashesDataKey hashes_data_key(key, version, fv.field);
         BaseDataValue inter_value(fv.value);
@@ -597,13 +599,13 @@ Status Redis::HMSet(const Slice& key, const std::vector<FieldValue>& fvs) {
         return Status::InvalidArgument("hash size overflow");
       }
       parsed_hashes_meta_value.ModifyCount(count);
-      batch.Put(handles_[kHashesMetaCF], base_meta_key.Encode(), meta_value);
+      batch.Put(handles_[kMetaCF], base_meta_key.Encode(), meta_value);
     }
   } else if (s.IsNotFound()) {
     EncodeFixed32(meta_value_buf, filtered_fvs.size());
     HashesMetaValue hashes_meta_value(Slice(meta_value_buf, sizeof(int32_t)));
     version = hashes_meta_value.UpdateVersion();
-    batch.Put(handles_[kHashesMetaCF], base_meta_key.Encode(), hashes_meta_value.Encode());
+    batch.Put(handles_[kMetaCF], base_meta_key.Encode(), hashes_meta_value.Encode());
     for (const auto& fv : filtered_fvs) {
       HashesDataKey hashes_data_key(key, version, fv.field);
       BaseDataValue inter_value(fv.value);
@@ -624,14 +626,17 @@ Status Redis::HSet(const Slice& key, const Slice& field, const Slice& value, int
   std::string meta_value;
 
   BaseMetaKey base_meta_key(key);
-  Status s = db_->Get(default_read_options_, handles_[kHashesMetaCF], base_meta_key.Encode(), &meta_value);
+  Status s = db_->Get(default_read_options_, handles_[kMetaCF], base_meta_key.Encode(), &meta_value);
   char meta_value_buf[4] = {0};
   if (s.ok()) {
     ParsedHashesMetaValue parsed_hashes_meta_value(&meta_value);
+    if (!parsed_hashes_meta_value.IsType(HashType)) {
+      return Status::InvalidArgument("WRONGTYPE Operation against a key holding the wrong kind of value");
+    }
     if (parsed_hashes_meta_value.IsStale() || parsed_hashes_meta_value.Count() == 0) {
       version = parsed_hashes_meta_value.InitialMetaValue();
       parsed_hashes_meta_value.SetCount(1);
-      batch.Put(handles_[kHashesMetaCF], base_meta_key.Encode(), meta_value);
+      batch.Put(handles_[kMetaCF], base_meta_key.Encode(), meta_value);
       HashesDataKey data_key(key, version, field);
       BaseDataValue internal_value(value);
       batch.Put(handles_[kHashesDataCF], data_key.Encode(), internal_value.Encode());
@@ -656,7 +661,7 @@ Status Redis::HSet(const Slice& key, const Slice& field, const Slice& value, int
         }
         parsed_hashes_meta_value.ModifyCount(1);
         BaseDataValue internal_value(value);
-        batch.Put(handles_[kHashesMetaCF], base_meta_key.Encode(), meta_value);
+        batch.Put(handles_[kMetaCF], base_meta_key.Encode(), meta_value);
         batch.Put(handles_[kHashesDataCF], hashes_data_key.Encode(), internal_value.Encode());
         *res = 1;
       } else {
@@ -667,7 +672,7 @@ Status Redis::HSet(const Slice& key, const Slice& field, const Slice& value, int
     EncodeFixed32(meta_value_buf, 1);
     HashesMetaValue meta_value(Slice(meta_value_buf, sizeof(int32_t)));
     version = meta_value.UpdateVersion();
-    batch.Put(handles_[kHashesMetaCF], base_meta_key.Encode(), meta_value.Encode());
+    batch.Put(handles_[kMetaCF], base_meta_key.Encode(), meta_value.Encode());
     HashesDataKey data_key(key, version, field);
     BaseDataValue internal_value(value);
     batch.Put(handles_[kHashesDataCF], data_key.Encode(), internal_value.Encode());
@@ -689,14 +694,14 @@ Status Redis::HSetnx(const Slice& key, const Slice& field, const Slice& value, i
 
   BaseMetaKey base_meta_key(key);
   BaseDataValue internal_value(value);
-  Status s = db_->Get(default_read_options_, handles_[kHashesMetaCF], base_meta_key.Encode(), &meta_value);
+  Status s = db_->Get(default_read_options_, handles_[kMetaCF], base_meta_key.Encode(), &meta_value);
   char meta_value_buf[4] = {0};
   if (s.ok()) {
     ParsedHashesMetaValue parsed_hashes_meta_value(&meta_value);
     if (parsed_hashes_meta_value.IsStale() || parsed_hashes_meta_value.Count() == 0) {
       version = parsed_hashes_meta_value.InitialMetaValue();
       parsed_hashes_meta_value.SetCount(1);
-      batch.Put(handles_[kHashesMetaCF], base_meta_key.Encode(), meta_value);
+      batch.Put(handles_[kMetaCF], base_meta_key.Encode(), meta_value);
       HashesDataKey hashes_data_key(key, version, field);
       batch.Put(handles_[kHashesDataCF], hashes_data_key.Encode(), internal_value.Encode());
       *ret = 1;
@@ -712,7 +717,7 @@ Status Redis::HSetnx(const Slice& key, const Slice& field, const Slice& value, i
           return Status::InvalidArgument("hash size overflow");
         }
         parsed_hashes_meta_value.ModifyCount(1);
-        batch.Put(handles_[kHashesMetaCF], base_meta_key.Encode(), meta_value);
+        batch.Put(handles_[kMetaCF], base_meta_key.Encode(), meta_value);
         batch.Put(handles_[kHashesDataCF], hashes_data_key.Encode(), internal_value.Encode());
         *ret = 1;
       } else {
@@ -723,7 +728,7 @@ Status Redis::HSetnx(const Slice& key, const Slice& field, const Slice& value, i
     EncodeFixed32(meta_value_buf, 1);
     HashesMetaValue hashes_meta_value(Slice(meta_value_buf, sizeof(int32_t)));
     version = hashes_meta_value.UpdateVersion();
-    batch.Put(handles_[kHashesMetaCF], base_meta_key.Encode(), hashes_meta_value.Encode());
+    batch.Put(handles_[kMetaCF], base_meta_key.Encode(), hashes_meta_value.Encode());
     HashesDataKey hashes_data_key(key, version, field);
     batch.Put(handles_[kHashesDataCF], hashes_data_key.Encode(), internal_value.Encode());
     *ret = 1;
@@ -743,7 +748,7 @@ Status Redis::HVals(const Slice& key, std::vector<std::string>* values) {
   read_options.snapshot = snapshot;
 
   BaseMetaKey base_meta_key(key);
-  Status s = db_->Get(read_options, handles_[kHashesMetaCF], base_meta_key.Encode(), &meta_value);
+  Status s = db_->Get(read_options, handles_[kMetaCF], base_meta_key.Encode(), &meta_value);
   if (s.ok()) {
     ParsedHashesMetaValue parsed_hashes_meta_value(&meta_value);
     if (parsed_hashes_meta_value.IsStale()) {
@@ -796,7 +801,7 @@ Status Redis::HScan(const Slice& key, int64_t cursor, const std::string& pattern
   read_options.snapshot = snapshot;
 
   BaseMetaKey base_meta_key(key);
-  Status s = db_->Get(read_options, handles_[kHashesMetaCF], base_meta_key.Encode(), &meta_value);
+  Status s = db_->Get(read_options, handles_[kMetaCF], base_meta_key.Encode(), &meta_value);
   if (s.ok()) {
     ParsedHashesMetaValue parsed_hashes_meta_value(&meta_value);
     if (parsed_hashes_meta_value.IsStale() || parsed_hashes_meta_value.Count() == 0) {
@@ -863,7 +868,7 @@ Status Redis::HScanx(const Slice& key, const std::string& start_field, const std
   read_options.snapshot = snapshot;
 
   BaseMetaKey base_meta_key(key);
-  Status s = db_->Get(read_options, handles_[kHashesMetaCF], base_meta_key.Encode(), &meta_value);
+  Status s = db_->Get(read_options, handles_[kMetaCF], base_meta_key.Encode(), &meta_value);
   if (s.ok()) {
     ParsedHashesMetaValue parsed_hashes_meta_value(&meta_value);
     if (parsed_hashes_meta_value.IsStale() || parsed_hashes_meta_value.Count() == 0) {
@@ -905,7 +910,7 @@ Status Redis::HScanx(const Slice& key, const std::string& start_field, const std
 Status Redis::HRandField(const Slice& key, int64_t count, bool with_values, std::vector<std::string>* res) {
   BaseMetaKey base_meta_key(key);
   std::string meta_value;
-  Status s = db_->Get(default_read_options_, handles_[kHashesMetaCF], base_meta_key.Encode(), &meta_value);
+  Status s = db_->Get(default_read_options_, handles_[kMetaCF], base_meta_key.Encode(), &meta_value);
   if (!s.ok()) {
     return s;
   }
@@ -996,7 +1001,7 @@ Status Redis::PKHScanRange(const Slice& key, const Slice& field_start, const std
   }
 
   BaseMetaKey base_meta_key(key);
-  Status s = db_->Get(read_options, handles_[kHashesMetaCF], base_meta_key.Encode(), &meta_value);
+  Status s = db_->Get(read_options, handles_[kMetaCF], base_meta_key.Encode(), &meta_value);
   if (s.ok()) {
     ParsedHashesMetaValue parsed_hashes_meta_value(&meta_value);
     if (parsed_hashes_meta_value.IsStale() || parsed_hashes_meta_value.Count() == 0) {
@@ -1057,7 +1062,7 @@ Status Redis::PKHRScanRange(const Slice& key, const Slice& field_start, const st
   }
 
   BaseMetaKey base_meta_key(key);
-  Status s = db_->Get(read_options, handles_[kHashesMetaCF], base_meta_key.Encode(), &meta_value);
+  Status s = db_->Get(read_options, handles_[kMetaCF], base_meta_key.Encode(), &meta_value);
   if (s.ok()) {
     ParsedHashesMetaValue parsed_hashes_meta_value(&meta_value);
     if (parsed_hashes_meta_value.IsStale() || parsed_hashes_meta_value.Count() == 0) {
@@ -1104,7 +1109,7 @@ Status Redis::HashesExpire(const Slice& key, uint64_t ttl) {
   ScopeRecordLock l(lock_mgr_, key);
 
   BaseMetaKey base_meta_key(key);
-  Status s = db_->Get(default_read_options_, handles_[kHashesMetaCF], base_meta_key.Encode(), &meta_value);
+  Status s = db_->Get(default_read_options_, handles_[kMetaCF], base_meta_key.Encode(), &meta_value);
   if (s.ok()) {
     ParsedHashesMetaValue parsed_hashes_meta_value(&meta_value);
     if (parsed_hashes_meta_value.IsStale()) {
@@ -1115,10 +1120,10 @@ Status Redis::HashesExpire(const Slice& key, uint64_t ttl) {
 
     if (ttl > 0) {
       parsed_hashes_meta_value.SetRelativeTimestamp(ttl);
-      s = db_->Put(default_write_options_, handles_[kHashesMetaCF], base_meta_key.Encode(), meta_value);
+      s = db_->Put(default_write_options_, handles_[kMetaCF], base_meta_key.Encode(), meta_value);
     } else {
       parsed_hashes_meta_value.InitialMetaValue();
-      s = db_->Put(default_write_options_, handles_[kHashesMetaCF], base_meta_key.Encode(), meta_value);
+      s = db_->Put(default_write_options_, handles_[kMetaCF], base_meta_key.Encode(), meta_value);
     }
   }
   return s;
@@ -1129,7 +1134,7 @@ Status Redis::HashesDel(const Slice& key) {
   ScopeRecordLock l(lock_mgr_, key);
 
   BaseMetaKey base_meta_key(key);
-  Status s = db_->Get(default_read_options_, handles_[kHashesMetaCF], base_meta_key.Encode(), &meta_value);
+  Status s = db_->Get(default_read_options_, handles_[kMetaCF], base_meta_key.Encode(), &meta_value);
   if (s.ok()) {
     ParsedHashesMetaValue parsed_hashes_meta_value(&meta_value);
     if (parsed_hashes_meta_value.IsStale()) {
@@ -1139,7 +1144,7 @@ Status Redis::HashesDel(const Slice& key) {
     } else {
       uint32_t statistic = parsed_hashes_meta_value.Count();
       parsed_hashes_meta_value.InitialMetaValue();
-      s = db_->Put(default_write_options_, handles_[kHashesMetaCF], base_meta_key.Encode(), meta_value);
+      s = db_->Put(default_write_options_, handles_[kMetaCF], base_meta_key.Encode(), meta_value);
       UpdateSpecificKeyStatistics(DataType::kHashes, key.ToString(), statistic);
     }
   }
@@ -1151,7 +1156,7 @@ Status Redis::HashesExpireat(const Slice& key, uint64_t timestamp) {
   ScopeRecordLock l(lock_mgr_, key);
 
   BaseMetaKey base_meta_key(key);
-  Status s = db_->Get(default_read_options_, handles_[kHashesMetaCF], base_meta_key.Encode(), &meta_value);
+  Status s = db_->Get(default_read_options_, handles_[kMetaCF], base_meta_key.Encode(), &meta_value);
   if (s.ok()) {
     ParsedHashesMetaValue parsed_hashes_meta_value(&meta_value);
     if (parsed_hashes_meta_value.IsStale()) {
@@ -1164,7 +1169,7 @@ Status Redis::HashesExpireat(const Slice& key, uint64_t timestamp) {
       } else {
         parsed_hashes_meta_value.InitialMetaValue();
       }
-      s = db_->Put(default_write_options_, handles_[kHashesMetaCF], base_meta_key.Encode(), meta_value);
+      s = db_->Put(default_write_options_, handles_[kMetaCF], base_meta_key.Encode(), meta_value);
     }
   }
   return s;
@@ -1175,7 +1180,7 @@ Status Redis::HashesPersist(const Slice& key) {
   ScopeRecordLock l(lock_mgr_, key);
 
   BaseMetaKey base_meta_key(key);
-  Status s = db_->Get(default_read_options_, handles_[kHashesMetaCF], base_meta_key.Encode(), &meta_value);
+  Status s = db_->Get(default_read_options_, handles_[kMetaCF], base_meta_key.Encode(), &meta_value);
   if (s.ok()) {
     ParsedHashesMetaValue parsed_hashes_meta_value(&meta_value);
     if (parsed_hashes_meta_value.IsStale()) {
@@ -1188,7 +1193,7 @@ Status Redis::HashesPersist(const Slice& key) {
         return Status::NotFound("Not have an associated timeout");
       } else {
         parsed_hashes_meta_value.SetEtime(0);
-        s = db_->Put(default_write_options_, handles_[kHashesMetaCF], base_meta_key.Encode(), meta_value);
+        s = db_->Put(default_write_options_, handles_[kMetaCF], base_meta_key.Encode(), meta_value);
       }
     }
   }
@@ -1199,7 +1204,7 @@ Status Redis::HashesTTL(const Slice& key, uint64_t* timestamp) {
   std::string meta_value;
 
   BaseMetaKey base_meta_key(key);
-  Status s = db_->Get(default_read_options_, handles_[kHashesMetaCF], base_meta_key.Encode(), &meta_value);
+  Status s = db_->Get(default_read_options_, handles_[kMetaCF], base_meta_key.Encode(), &meta_value);
   if (s.ok()) {
     ParsedHashesMetaValue parsed_hashes_meta_value(&meta_value);
     if (parsed_hashes_meta_value.IsStale()) {
@@ -1233,7 +1238,7 @@ void Redis::ScanHashes() {
   auto current_time = static_cast<int32_t>(time(nullptr));
 
   INFO("***************rocksdb instance: {} Hashes Meta Data***************", index_);
-  auto meta_iter = db_->NewIterator(iterator_options, handles_[kHashesMetaCF]);
+  auto meta_iter = db_->NewIterator(iterator_options, handles_[kMetaCF]);
   for (meta_iter->SeekToFirst(); meta_iter->Valid(); meta_iter->Next()) {
     ParsedHashesMetaValue parsed_hashes_meta_value(meta_iter->value());
     uint64_t survival_time = 0;

--- a/src/storage/src/redis_lists.cc
+++ b/src/storage/src/redis_lists.cc
@@ -30,7 +30,7 @@ Status Redis::ScanListsKeyNum(KeyInfo* key_info) {
   int64_t curtime;
   rocksdb::Env::Default()->GetCurrentTime(&curtime);
 
-  rocksdb::Iterator* iter = db_->NewIterator(iterator_options, handles_[kListsMetaCF]);
+  rocksdb::Iterator* iter = db_->NewIterator(iterator_options, handles_[kMetaCF]);
   for (iter->SeekToFirst(); iter->Valid(); iter->Next()) {
     ParsedListsMetaValue parsed_lists_meta_value(iter->value());
     if (parsed_lists_meta_value.IsStale() || parsed_lists_meta_value.Count() == 0) {
@@ -64,7 +64,7 @@ Status Redis::ListsPKPatternMatchDel(const std::string& pattern, int32_t* ret) {
   int32_t total_delete = 0;
   Status s;
   rocksdb::WriteBatch batch;
-  rocksdb::Iterator* iter = db_->NewIterator(iterator_options, handles_[kListsMetaCF]);
+  rocksdb::Iterator* iter = db_->NewIterator(iterator_options, handles_[kMetaCF]);
   iter->SeekToFirst();
   while (iter->Valid()) {
     ParsedBaseMetaKey parsed_meta_key(iter->key().ToString());
@@ -74,7 +74,7 @@ Status Redis::ListsPKPatternMatchDel(const std::string& pattern, int32_t* ret) {
         (StringMatch(pattern.data(), pattern.size(), parsed_meta_key.Key().data(), parsed_meta_key.Key().size(), 0) !=
          0)) {
       parsed_lists_meta_value.InitialMetaValue();
-      batch.Put(handles_[kListsMetaCF], iter->key(), meta_value);
+      batch.Put(handles_[kMetaCF], iter->key(), meta_value);
     }
     if (static_cast<size_t>(batch.Count()) >= BATCH_DELETE_LIMIT) {
       s = db_->Write(default_write_options_, &batch);
@@ -109,7 +109,7 @@ Status Redis::LIndex(const Slice& key, int64_t index, std::string* element) {
   std::string meta_value;
 
   BaseMetaKey base_meta_key(key);
-  Status s = db_->Get(read_options, handles_[kListsMetaCF], base_meta_key.Encode(), &meta_value);
+  Status s = db_->Get(read_options, handles_[kMetaCF], base_meta_key.Encode(), &meta_value);
   if (s.ok()) {
     ParsedListsMetaValue parsed_lists_meta_value(&meta_value);
     uint64_t version = parsed_lists_meta_value.Version();
@@ -143,7 +143,7 @@ Status Redis::LInsert(const Slice& key, const BeforeOrAfter& before_or_after, co
   std::string meta_value;
 
   BaseMetaKey base_meta_key(key);
-  Status s = db_->Get(default_read_options_, handles_[kListsMetaCF], base_meta_key.Encode(), &meta_value);
+  Status s = db_->Get(default_read_options_, handles_[kMetaCF], base_meta_key.Encode(), &meta_value);
   if (s.ok()) {
     ParsedListsMetaValue parsed_lists_meta_value(&meta_value);
     if (parsed_lists_meta_value.IsStale()) {
@@ -225,7 +225,7 @@ Status Redis::LInsert(const Slice& key, const BeforeOrAfter& before_or_after, co
           parsed_lists_meta_value.ModifyRightIndex(1);
         }
         parsed_lists_meta_value.ModifyCount(1);
-        batch.Put(handles_[kListsMetaCF], base_meta_key.Encode(), meta_value);
+        batch.Put(handles_[kMetaCF], base_meta_key.Encode(), meta_value);
         ListsDataKey lists_target_key(key, version, target_index);
         BaseDataValue i_val(value);
         batch.Put(handles_[kListsDataCF], lists_target_key.Encode(), i_val.Encode());
@@ -244,7 +244,7 @@ Status Redis::LLen(const Slice& key, uint64_t* len) {
   std::string meta_value;
 
   BaseMetaKey base_meta_key(key);
-  Status s = db_->Get(default_read_options_, handles_[kListsMetaCF], base_meta_key.Encode(), &meta_value);
+  Status s = db_->Get(default_read_options_, handles_[kMetaCF], base_meta_key.Encode(), &meta_value);
   if (s.ok()) {
     ParsedListsMetaValue parsed_lists_meta_value(&meta_value);
     if (parsed_lists_meta_value.IsStale()) {
@@ -269,7 +269,7 @@ Status Redis::LPop(const Slice& key, int64_t count, std::vector<std::string>* el
   std::string meta_value;
 
   BaseMetaKey base_meta_key(key);
-  Status s = db_->Get(default_read_options_, handles_[kListsMetaCF], base_meta_key.Encode(), &meta_value);
+  Status s = db_->Get(default_read_options_, handles_[kMetaCF], base_meta_key.Encode(), &meta_value);
   if (s.ok()) {
     ParsedListsMetaValue parsed_lists_meta_value(&meta_value);
     if (parsed_lists_meta_value.IsStale()) {
@@ -293,7 +293,7 @@ Status Redis::LPop(const Slice& key, int64_t count, std::vector<std::string>* el
         parsed_lists_meta_value.ModifyCount(-1);
         parsed_lists_meta_value.ModifyLeftIndex(-1);
       }
-      batch.Put(handles_[kListsMetaCF], base_meta_key.Encode(), meta_value);
+      batch.Put(handles_[kMetaCF], base_meta_key.Encode(), meta_value);
       delete iter;
     }
   }
@@ -317,7 +317,7 @@ Status Redis::LPush(const Slice& key, const std::vector<std::string>& values, ui
   std::string meta_value;
 
   BaseMetaKey base_meta_key(key);
-  Status s = db_->Get(default_read_options_, handles_[kListsMetaCF], base_meta_key.Encode(), &meta_value);
+  Status s = db_->Get(default_read_options_, handles_[kMetaCF], base_meta_key.Encode(), &meta_value);
   if (s.ok()) {
     ParsedListsMetaValue parsed_lists_meta_value(&meta_value);
     if (parsed_lists_meta_value.IsStale() || parsed_lists_meta_value.Count() == 0) {
@@ -333,7 +333,7 @@ Status Redis::LPush(const Slice& key, const std::vector<std::string>& values, ui
       BaseDataValue i_val(value);
       batch.Put(handles_[kListsDataCF], lists_data_key.Encode(), i_val.Encode());
     }
-    batch.Put(handles_[kListsMetaCF], base_meta_key.Encode(), meta_value);
+    batch.Put(handles_[kMetaCF], base_meta_key.Encode(), meta_value);
     *ret = parsed_lists_meta_value.Count();
   } else if (s.IsNotFound()) {
     char str[8];
@@ -347,7 +347,7 @@ Status Redis::LPush(const Slice& key, const std::vector<std::string>& values, ui
       BaseDataValue i_val(value);
       batch.Put(handles_[kListsDataCF], lists_data_key.Encode(), i_val.Encode());
     }
-    batch.Put(handles_[kListsMetaCF], base_meta_key.Encode(), lists_meta_value.Encode());
+    batch.Put(handles_[kMetaCF], base_meta_key.Encode(), lists_meta_value.Encode());
     *ret = lists_meta_value.RightIndex() - lists_meta_value.LeftIndex() - 1;
   } else {
     return s;
@@ -363,7 +363,7 @@ Status Redis::LPushx(const Slice& key, const std::vector<std::string>& values, u
   std::string meta_value;
 
   BaseMetaKey base_meta_key(key);
-  Status s = db_->Get(default_read_options_, handles_[kListsMetaCF], base_meta_key.Encode(), &meta_value);
+  Status s = db_->Get(default_read_options_, handles_[kMetaCF], base_meta_key.Encode(), &meta_value);
   if (s.ok()) {
     ParsedListsMetaValue parsed_lists_meta_value(&meta_value);
     if (parsed_lists_meta_value.IsStale()) {
@@ -380,7 +380,7 @@ Status Redis::LPushx(const Slice& key, const std::vector<std::string>& values, u
         BaseDataValue i_val(value);
         batch.Put(handles_[kListsDataCF], lists_data_key.Encode(), i_val.Encode());
       }
-      batch.Put(handles_[kListsMetaCF], base_meta_key.Encode(), meta_value);
+      batch.Put(handles_[kMetaCF], base_meta_key.Encode(), meta_value);
       *len = parsed_lists_meta_value.Count();
       return db_->Write(default_write_options_, &batch);
     }
@@ -397,7 +397,7 @@ Status Redis::LRange(const Slice& key, int64_t start, int64_t stop, std::vector<
 
   std::string meta_value;
   BaseMetaKey base_meta_key(key);
-  Status s = db_->Get(read_options, handles_[kListsMetaCF], base_meta_key.Encode(), &meta_value);
+  Status s = db_->Get(read_options, handles_[kMetaCF], base_meta_key.Encode(), &meta_value);
   if (s.ok()) {
     ParsedListsMetaValue parsed_lists_meta_value(&meta_value);
     if (parsed_lists_meta_value.IsStale()) {
@@ -448,7 +448,7 @@ Status Redis::LRangeWithTTL(const Slice& key, int64_t start, int64_t stop, std::
 
   std::string meta_value;
   BaseMetaKey base_meta_key(key);
-  Status s = db_->Get(read_options, handles_[kListsMetaCF], base_meta_key.Encode(), &meta_value);
+  Status s = db_->Get(read_options, handles_[kMetaCF], base_meta_key.Encode(), &meta_value);
   if (s.ok()) {
     ParsedListsMetaValue parsed_lists_meta_value(&meta_value);
     if (parsed_lists_meta_value.Count() == 0) {
@@ -506,7 +506,7 @@ Status Redis::LRem(const Slice& key, int64_t count, const Slice& value, uint64_t
   std::string meta_value;
 
   BaseMetaKey base_meta_key(key);
-  Status s = db_->Get(default_read_options_, handles_[kListsMetaCF], base_meta_key.Encode(), &meta_value);
+  Status s = db_->Get(default_read_options_, handles_[kMetaCF], base_meta_key.Encode(), &meta_value);
   if (s.ok()) {
     ParsedListsMetaValue parsed_lists_meta_value(&meta_value);
     if (parsed_lists_meta_value.IsStale()) {
@@ -607,7 +607,7 @@ Status Redis::LRem(const Slice& key, int64_t count, const Slice& value, uint64_t
           parsed_lists_meta_value.ModifyRightIndex(-target_index.size());
         }
         parsed_lists_meta_value.ModifyCount(-target_index.size());
-        batch.Put(handles_[kListsMetaCF], base_meta_key.Encode(), meta_value);
+        batch.Put(handles_[kMetaCF], base_meta_key.Encode(), meta_value);
         for (const auto& idx : delete_index) {
           ListsDataKey lists_data_key(key, version, idx);
           batch.Delete(handles_[kListsDataCF], lists_data_key.Encode());
@@ -628,7 +628,7 @@ Status Redis::LSet(const Slice& key, int64_t index, const Slice& value) {
   std::string meta_value;
 
   BaseMetaKey base_meta_key(key);
-  Status s = db_->Get(default_read_options_, handles_[kListsMetaCF], base_meta_key.Encode(), &meta_value);
+  Status s = db_->Get(default_read_options_, handles_[kMetaCF], base_meta_key.Encode(), &meta_value);
   if (s.ok()) {
     ParsedListsMetaValue parsed_lists_meta_value(&meta_value);
     if (parsed_lists_meta_value.IsStale()) {
@@ -661,7 +661,7 @@ Status Redis::LTrim(const Slice& key, int64_t start, int64_t stop) {
   std::string meta_value;
 
   BaseMetaKey base_meta_key(key);
-  Status s = db_->Get(default_read_options_, handles_[kListsMetaCF], base_meta_key.Encode(), &meta_value);
+  Status s = db_->Get(default_read_options_, handles_[kMetaCF], base_meta_key.Encode(), &meta_value);
   if (s.ok()) {
     ParsedListsMetaValue parsed_lists_meta_value(&meta_value);
     uint64_t version = parsed_lists_meta_value.Version();
@@ -678,7 +678,7 @@ Status Redis::LTrim(const Slice& key, int64_t start, int64_t stop) {
       if (sublist_left_index > sublist_right_index || sublist_left_index > origin_right_index ||
           sublist_right_index < origin_left_index) {
         parsed_lists_meta_value.InitialMetaValue();
-        batch.Put(handles_[kListsMetaCF], base_meta_key.Encode(), meta_value);
+        batch.Put(handles_[kMetaCF], base_meta_key.Encode(), meta_value);
       } else {
         if (sublist_left_index < origin_left_index) {
           sublist_left_index = origin_left_index;
@@ -693,7 +693,7 @@ Status Redis::LTrim(const Slice& key, int64_t start, int64_t stop) {
         parsed_lists_meta_value.ModifyLeftIndex(-(sublist_left_index - origin_left_index));
         parsed_lists_meta_value.ModifyRightIndex(-(origin_right_index - sublist_right_index));
         parsed_lists_meta_value.ModifyCount(-delete_node_num);
-        batch.Put(handles_[kListsMetaCF], base_meta_key.Encode(), meta_value);
+        batch.Put(handles_[kMetaCF], base_meta_key.Encode(), meta_value);
         for (uint64_t idx = origin_left_index; idx < sublist_left_index; ++idx) {
           statistic++;
           ListsDataKey lists_data_key(key, version, idx);
@@ -724,7 +724,7 @@ Status Redis::RPop(const Slice& key, int64_t count, std::vector<std::string>* el
   std::string meta_value;
 
   BaseMetaKey base_meta_key(key);
-  Status s = db_->Get(default_read_options_, handles_[kListsMetaCF], base_meta_key.Encode(), &meta_value);
+  Status s = db_->Get(default_read_options_, handles_[kMetaCF], base_meta_key.Encode(), &meta_value);
   if (s.ok()) {
     ParsedListsMetaValue parsed_lists_meta_value(&meta_value);
     if (parsed_lists_meta_value.IsStale()) {
@@ -749,7 +749,7 @@ Status Redis::RPop(const Slice& key, int64_t count, std::vector<std::string>* el
         parsed_lists_meta_value.ModifyCount(-1);
         parsed_lists_meta_value.ModifyRightIndex(-1);
       }
-      batch.Put(handles_[kListsMetaCF], base_meta_key.Encode(), meta_value);
+      batch.Put(handles_[kMetaCF], base_meta_key.Encode(), meta_value);
       delete iter;
     }
   }
@@ -772,7 +772,7 @@ Status Redis::RPoplpush(const Slice& source, const Slice& destination, std::stri
   if (source.compare(destination) == 0) {
     std::string meta_value;
     BaseMetaKey base_source(source);
-    s = db_->Get(default_read_options_, handles_[kListsMetaCF], base_source.Encode(), &meta_value);
+    s = db_->Get(default_read_options_, handles_[kMetaCF], base_source.Encode(), &meta_value);
     if (s.ok()) {
       ParsedListsMetaValue parsed_lists_meta_value(&meta_value);
       if (parsed_lists_meta_value.IsStale()) {
@@ -799,7 +799,7 @@ Status Redis::RPoplpush(const Slice& source, const Slice& destination, std::stri
             statistic++;
             parsed_lists_meta_value.ModifyRightIndex(-1);
             parsed_lists_meta_value.ModifyLeftIndex(1);
-            batch.Put(handles_[kListsMetaCF], base_source.Encode(), meta_value);
+            batch.Put(handles_[kMetaCF], base_source.Encode(), meta_value);
             s = db_->Write(default_write_options_, &batch);
             UpdateSpecificKeyStatistics(DataType::kLists, source.ToString(), statistic);
             return s;
@@ -817,7 +817,7 @@ Status Redis::RPoplpush(const Slice& source, const Slice& destination, std::stri
   std::string target;
   std::string source_meta_value;
   BaseMetaKey base_source(source);
-  s = db_->Get(default_read_options_, handles_[kListsMetaCF], base_source.Encode(), &source_meta_value);
+  s = db_->Get(default_read_options_, handles_[kMetaCF], base_source.Encode(), &source_meta_value);
   if (s.ok()) {
     ParsedListsMetaValue parsed_lists_meta_value(&source_meta_value);
     if (parsed_lists_meta_value.IsStale()) {
@@ -834,7 +834,7 @@ Status Redis::RPoplpush(const Slice& source, const Slice& destination, std::stri
         statistic++;
         parsed_lists_meta_value.ModifyCount(-1);
         parsed_lists_meta_value.ModifyRightIndex(-1);
-        batch.Put(handles_[kListsMetaCF], base_source.Encode(), source_meta_value);
+        batch.Put(handles_[kMetaCF], base_source.Encode(), source_meta_value);
       } else {
         return s;
       }
@@ -845,7 +845,7 @@ Status Redis::RPoplpush(const Slice& source, const Slice& destination, std::stri
 
   std::string destination_meta_value;
   BaseMetaKey base_destination(destination);
-  s = db_->Get(default_read_options_, handles_[kListsMetaCF], base_destination.Encode(), &destination_meta_value);
+  s = db_->Get(default_read_options_, handles_[kMetaCF], base_destination.Encode(), &destination_meta_value);
   if (s.ok()) {
     ParsedListsMetaValue parsed_lists_meta_value(&destination_meta_value);
     if (parsed_lists_meta_value.IsStale() || parsed_lists_meta_value.Count() == 0) {
@@ -858,7 +858,7 @@ Status Redis::RPoplpush(const Slice& source, const Slice& destination, std::stri
     batch.Put(handles_[kListsDataCF], lists_data_key.Encode(), target);
     parsed_lists_meta_value.ModifyCount(1);
     parsed_lists_meta_value.ModifyLeftIndex(1);
-    batch.Put(handles_[kListsMetaCF], base_destination.Encode(), destination_meta_value);
+    batch.Put(handles_[kMetaCF], base_destination.Encode(), destination_meta_value);
   } else if (s.IsNotFound()) {
     char str[8];
     EncodeFixed64(str, 1);
@@ -868,7 +868,7 @@ Status Redis::RPoplpush(const Slice& source, const Slice& destination, std::stri
     ListsDataKey lists_data_key(destination, version, target_index);
     batch.Put(handles_[kListsDataCF], lists_data_key.Encode(), target);
     lists_meta_value.ModifyLeftIndex(1);
-    batch.Put(handles_[kListsMetaCF], base_destination.Encode(), lists_meta_value.Encode());
+    batch.Put(handles_[kMetaCF], base_destination.Encode(), lists_meta_value.Encode());
   } else {
     return s;
   }
@@ -892,7 +892,7 @@ Status Redis::RPush(const Slice& key, const std::vector<std::string>& values, ui
   std::string meta_value;
 
   BaseMetaKey base_meta_key(key);
-  Status s = db_->Get(default_read_options_, handles_[kListsMetaCF], base_meta_key.Encode(), &meta_value);
+  Status s = db_->Get(default_read_options_, handles_[kMetaCF], base_meta_key.Encode(), &meta_value);
   if (s.ok()) {
     ParsedListsMetaValue parsed_lists_meta_value(&meta_value);
     if (parsed_lists_meta_value.IsStale() || parsed_lists_meta_value.Count() == 0) {
@@ -908,7 +908,7 @@ Status Redis::RPush(const Slice& key, const std::vector<std::string>& values, ui
       BaseDataValue i_val(value);
       batch.Put(handles_[kListsDataCF], lists_data_key.Encode(), i_val.Encode());
     }
-    batch.Put(handles_[kListsMetaCF], base_meta_key.Encode(), meta_value);
+    batch.Put(handles_[kMetaCF], base_meta_key.Encode(), meta_value);
     *ret = parsed_lists_meta_value.Count();
   } else if (s.IsNotFound()) {
     char str[8];
@@ -922,7 +922,7 @@ Status Redis::RPush(const Slice& key, const std::vector<std::string>& values, ui
       BaseDataValue i_val(value);
       batch.Put(handles_[kListsDataCF], lists_data_key.Encode(), i_val.Encode());
     }
-    batch.Put(handles_[kListsMetaCF], base_meta_key.Encode(), lists_meta_value.Encode());
+    batch.Put(handles_[kMetaCF], base_meta_key.Encode(), lists_meta_value.Encode());
     *ret = lists_meta_value.RightIndex() - lists_meta_value.LeftIndex() - 1;
   } else {
     return s;
@@ -938,7 +938,7 @@ Status Redis::RPushx(const Slice& key, const std::vector<std::string>& values, u
   std::string meta_value;
 
   BaseMetaKey base_meta_key(key);
-  Status s = db_->Get(default_read_options_, handles_[kListsMetaCF], base_meta_key.Encode(), &meta_value);
+  Status s = db_->Get(default_read_options_, handles_[kMetaCF], base_meta_key.Encode(), &meta_value);
   if (s.ok()) {
     ParsedListsMetaValue parsed_lists_meta_value(&meta_value);
     if (parsed_lists_meta_value.IsStale()) {
@@ -955,7 +955,7 @@ Status Redis::RPushx(const Slice& key, const std::vector<std::string>& values, u
         BaseDataValue i_val(value);
         batch.Put(handles_[kListsDataCF], lists_data_key.Encode(), i_val.Encode());
       }
-      batch.Put(handles_[kListsMetaCF], base_meta_key.Encode(), meta_value);
+      batch.Put(handles_[kMetaCF], base_meta_key.Encode(), meta_value);
       *len = parsed_lists_meta_value.Count();
       return db_->Write(default_write_options_, &batch);
     }
@@ -968,7 +968,7 @@ Status Redis::ListsExpire(const Slice& key, uint64_t ttl) {
   ScopeRecordLock l(lock_mgr_, key);
 
   BaseMetaKey base_meta_key(key);
-  Status s = db_->Get(default_read_options_, handles_[kListsMetaCF], base_meta_key.Encode(), &meta_value);
+  Status s = db_->Get(default_read_options_, handles_[kMetaCF], base_meta_key.Encode(), &meta_value);
   if (s.ok()) {
     ParsedListsMetaValue parsed_lists_meta_value(&meta_value);
     if (parsed_lists_meta_value.IsStale()) {
@@ -979,10 +979,10 @@ Status Redis::ListsExpire(const Slice& key, uint64_t ttl) {
 
     if (ttl > 0) {
       parsed_lists_meta_value.SetRelativeTimestamp(ttl);
-      s = db_->Put(default_write_options_, handles_[kListsMetaCF], base_meta_key.Encode(), meta_value);
+      s = db_->Put(default_write_options_, handles_[kMetaCF], base_meta_key.Encode(), meta_value);
     } else {
       parsed_lists_meta_value.InitialMetaValue();
-      s = db_->Put(default_write_options_, handles_[kListsMetaCF], base_meta_key.Encode(), meta_value);
+      s = db_->Put(default_write_options_, handles_[kMetaCF], base_meta_key.Encode(), meta_value);
     }
   }
   return s;
@@ -993,7 +993,7 @@ Status Redis::ListsDel(const Slice& key) {
   ScopeRecordLock l(lock_mgr_, key);
 
   BaseMetaKey base_meta_key(key);
-  Status s = db_->Get(default_read_options_, handles_[kListsMetaCF], base_meta_key.Encode(), &meta_value);
+  Status s = db_->Get(default_read_options_, handles_[kMetaCF], base_meta_key.Encode(), &meta_value);
   if (s.ok()) {
     ParsedListsMetaValue parsed_lists_meta_value(&meta_value);
     if (parsed_lists_meta_value.IsStale()) {
@@ -1003,7 +1003,7 @@ Status Redis::ListsDel(const Slice& key) {
     } else {
       uint32_t statistic = parsed_lists_meta_value.Count();
       parsed_lists_meta_value.InitialMetaValue();
-      s = db_->Put(default_write_options_, handles_[kListsMetaCF], base_meta_key.Encode(), meta_value);
+      s = db_->Put(default_write_options_, handles_[kMetaCF], base_meta_key.Encode(), meta_value);
       UpdateSpecificKeyStatistics(DataType::kLists, key.ToString(), statistic);
     }
   }
@@ -1015,7 +1015,7 @@ Status Redis::ListsExpireat(const Slice& key, uint64_t timestamp) {
   ScopeRecordLock l(lock_mgr_, key);
 
   BaseMetaKey base_meta_key(key);
-  Status s = db_->Get(default_read_options_, handles_[kListsMetaCF], base_meta_key.Encode(), &meta_value);
+  Status s = db_->Get(default_read_options_, handles_[kMetaCF], base_meta_key.Encode(), &meta_value);
   if (s.ok()) {
     ParsedListsMetaValue parsed_lists_meta_value(&meta_value);
     if (parsed_lists_meta_value.IsStale()) {
@@ -1028,7 +1028,7 @@ Status Redis::ListsExpireat(const Slice& key, uint64_t timestamp) {
       } else {
         parsed_lists_meta_value.InitialMetaValue();
       }
-      return db_->Put(default_write_options_, handles_[kListsMetaCF], base_meta_key.Encode(), meta_value);
+      return db_->Put(default_write_options_, handles_[kMetaCF], base_meta_key.Encode(), meta_value);
     }
   }
   return s;
@@ -1038,7 +1038,7 @@ Status Redis::ListsPersist(const Slice& key) {
   std::string meta_value;
   ScopeRecordLock l(lock_mgr_, key);
   BaseMetaKey base_meta_key(key);
-  Status s = db_->Get(default_read_options_, handles_[kListsMetaCF], base_meta_key.Encode(), &meta_value);
+  Status s = db_->Get(default_read_options_, handles_[kMetaCF], base_meta_key.Encode(), &meta_value);
   if (s.ok()) {
     ParsedListsMetaValue parsed_lists_meta_value(&meta_value);
     if (parsed_lists_meta_value.IsStale()) {
@@ -1051,7 +1051,7 @@ Status Redis::ListsPersist(const Slice& key) {
         return Status::NotFound("Not have an associated timeout");
       } else {
         parsed_lists_meta_value.SetEtime(0);
-        return db_->Put(default_write_options_, handles_[kListsMetaCF], base_meta_key.Encode(), meta_value);
+        return db_->Put(default_write_options_, handles_[kMetaCF], base_meta_key.Encode(), meta_value);
       }
     }
   }
@@ -1062,7 +1062,7 @@ Status Redis::ListsTTL(const Slice& key, uint64_t* timestamp) {
   std::string meta_value;
 
   BaseMetaKey base_meta_key(key);
-  Status s = db_->Get(default_read_options_, handles_[kListsMetaCF], base_meta_key.Encode(), &meta_value);
+  Status s = db_->Get(default_read_options_, handles_[kMetaCF], base_meta_key.Encode(), &meta_value);
   if (s.ok()) {
     ParsedListsMetaValue parsed_lists_meta_value(&meta_value);
     if (parsed_lists_meta_value.IsStale()) {
@@ -1096,7 +1096,7 @@ void Redis::ScanLists() {
   auto current_time = static_cast<int32_t>(time(nullptr));
 
   INFO("***************rocksdb instance: {} List Meta Data***************", index_);
-  auto meta_iter = db_->NewIterator(iterator_options, handles_[kListsMetaCF]);
+  auto meta_iter = db_->NewIterator(iterator_options, handles_[kMetaCF]);
   for (meta_iter->SeekToFirst(); meta_iter->Valid(); meta_iter->Next()) {
     ParsedListsMetaValue parsed_lists_meta_value(meta_iter->value());
     ParsedBaseMetaKey parsed_meta_key(meta_iter->value());

--- a/src/storage/src/redis_sets.cc
+++ b/src/storage/src/redis_sets.cc
@@ -20,6 +20,7 @@
 #include "src/scope_snapshot.h"
 #include "storage/util.h"
 
+rocksdb::Slice SetType("s");
 namespace storage {
 rocksdb::Status Redis::ScanSetsKeyNum(KeyInfo* key_info) {
   uint64_t keys = 0;
@@ -36,7 +37,7 @@ rocksdb::Status Redis::ScanSetsKeyNum(KeyInfo* key_info) {
   int64_t curtime;
   rocksdb::Env::Default()->GetCurrentTime(&curtime);
 
-  rocksdb::Iterator* iter = db_->NewIterator(iterator_options, handles_[kSetsMetaCF]);
+  rocksdb::Iterator* iter = db_->NewIterator(iterator_options, handles_[kMetaCF]);
   for (iter->SeekToFirst(); iter->Valid(); iter->Next()) {
     ParsedSetsMetaValue parsed_sets_meta_value(iter->value());
     if (parsed_sets_meta_value.IsStale() || parsed_sets_meta_value.Count() == 0) {
@@ -70,7 +71,7 @@ rocksdb::Status Redis::SetsPKPatternMatchDel(const std::string& pattern, int32_t
   int32_t total_delete = 0;
   rocksdb::Status s;
   rocksdb::WriteBatch batch;
-  rocksdb::Iterator* iter = db_->NewIterator(iterator_options, handles_[kSetsMetaCF]);
+  rocksdb::Iterator* iter = db_->NewIterator(iterator_options, handles_[kMetaCF]);
   iter->SeekToFirst();
   while (iter->Valid()) {
     ParsedBaseMetaKey parsed_meta_key(iter->key());
@@ -80,7 +81,7 @@ rocksdb::Status Redis::SetsPKPatternMatchDel(const std::string& pattern, int32_t
         (StringMatch(pattern.data(), pattern.size(), parsed_meta_key.Key().data(), parsed_meta_key.Key().size(), 0) !=
          0)) {
       parsed_sets_meta_value.InitialMetaValue();
-      batch.Put(handles_[kSetsMetaCF], iter->key(), meta_value);
+      batch.Put(handles_[kMetaCF], iter->key(), meta_value);
     }
     if (static_cast<size_t>(batch.Count()) >= BATCH_DELETE_LIMIT) {
       s = db_->Write(default_write_options_, &batch);
@@ -122,16 +123,19 @@ rocksdb::Status Redis::SAdd(const Slice& key, const std::vector<std::string>& me
   std::string meta_value;
 
   BaseMetaKey base_meta_key(key);
-  rocksdb::Status s = db_->Get(default_read_options_, handles_[kSetsMetaCF], base_meta_key.Encode(), &meta_value);
+  rocksdb::Status s = db_->Get(default_read_options_, handles_[kMetaCF], base_meta_key.Encode(), &meta_value);
   if (s.ok()) {
     ParsedSetsMetaValue parsed_sets_meta_value(&meta_value);
+    if (!parsed_sets_meta_value.IsType(SetType)) {
+        return Status::InvalidArgument("WRONGTYPE Operation against a key holding the wrong kind of value");;
+    }
     if (parsed_sets_meta_value.IsStale() || parsed_sets_meta_value.Count() == 0) {
       version = parsed_sets_meta_value.InitialMetaValue();
       if (!parsed_sets_meta_value.check_set_count(static_cast<int32_t>(filtered_members.size()))) {
         return Status::InvalidArgument("set size overflow");
       }
       parsed_sets_meta_value.SetCount(static_cast<int32_t>(filtered_members.size()));
-      batch.Put(handles_[kSetsMetaCF], base_meta_key.Encode(), meta_value);
+      batch.Put(handles_[kMetaCF], base_meta_key.Encode(), meta_value);
       for (const auto& member : filtered_members) {
         SetsMemberKey sets_member_key(key, version, member);
         BaseDataValue iter_value(Slice{});
@@ -162,15 +166,16 @@ rocksdb::Status Redis::SAdd(const Slice& key, const std::vector<std::string>& me
           return Status::InvalidArgument("set size overflow");
         }
         parsed_sets_meta_value.ModifyCount(cnt);
-        batch.Put(handles_[kSetsMetaCF], base_meta_key.Encode(), meta_value);
+        batch.Put(handles_[kMetaCF], base_meta_key.Encode(), meta_value);
       }
     }
   } else if (s.IsNotFound()) {
-    char str[4];
-    EncodeFixed32(str, filtered_members.size());
-    SetsMetaValue sets_meta_value(Slice(str, sizeof(int32_t)));
+    char str[5];
+    EncodeFixed8(str, 's');
+    EncodeFixed32(str + 1, filtered_members.size());
+    SetsMetaValue sets_meta_value(Slice(str, 5));
     version = sets_meta_value.UpdateVersion();
-    batch.Put(handles_[kSetsMetaCF], base_meta_key.Encode(), sets_meta_value.Encode());
+    batch.Put(handles_[kMetaCF], base_meta_key.Encode(), sets_meta_value.Encode());
     for (const auto& member : filtered_members) {
       SetsMemberKey sets_member_key(key, version, member);
       BaseDataValue i_val(Slice{});
@@ -188,9 +193,12 @@ rocksdb::Status Redis::SCard(const Slice& key, int32_t* ret) {
   std::string meta_value;
 
   BaseMetaKey base_meta_key(key);
-  rocksdb::Status s = db_->Get(default_read_options_, handles_[kSetsMetaCF], base_meta_key.Encode(), &meta_value);
+  rocksdb::Status s = db_->Get(default_read_options_, handles_[kMetaCF], base_meta_key.Encode(), &meta_value);
   if (s.ok()) {
     ParsedSetsMetaValue parsed_sets_meta_value(&meta_value);
+    if (!parsed_sets_meta_value.IsType(SetType)) {
+      return Status::InvalidArgument("WRONGTYPE Operation against a key holding the wrong kind of value");;
+    }
     if (parsed_sets_meta_value.IsStale()) {
       return rocksdb::Status::NotFound("Stale");
     } else {
@@ -220,7 +228,7 @@ rocksdb::Status Redis::SDiff(const std::vector<std::string>& keys, std::vector<s
 
   for (uint32_t idx = 1; idx < keys.size(); ++idx) {
     BaseMetaKey base_meta_key(keys[idx]);
-    s = db_->Get(read_options, handles_[kSetsMetaCF], base_meta_key.Encode(), &meta_value);
+    s = db_->Get(read_options, handles_[kMetaCF], base_meta_key.Encode(), &meta_value);
     if (s.ok()) {
       ParsedSetsMetaValue parsed_sets_meta_value(&meta_value);
       if (!parsed_sets_meta_value.IsStale() && parsed_sets_meta_value.Count() != 0) {
@@ -232,7 +240,7 @@ rocksdb::Status Redis::SDiff(const std::vector<std::string>& keys, std::vector<s
   }
 
   BaseMetaKey base_meta_key0(keys[0]);
-  s = db_->Get(read_options, handles_[kSetsMetaCF], base_meta_key0.Encode(), &meta_value);
+  s = db_->Get(read_options, handles_[kMetaCF], base_meta_key0.Encode(), &meta_value);
   if (s.ok()) {
     ParsedSetsMetaValue parsed_sets_meta_value(&meta_value);
     if (!parsed_sets_meta_value.IsStale() && parsed_sets_meta_value.Count() != 0) {
@@ -292,7 +300,7 @@ rocksdb::Status Redis::SDiffstore(const Slice& destination, const std::vector<st
 
   for (uint32_t idx = 1; idx < keys.size(); ++idx) {
     BaseMetaKey base_meta_key(keys[idx]);
-    s = db_->Get(read_options, handles_[kSetsMetaCF], base_meta_key.Encode(), &meta_value);
+    s = db_->Get(read_options, handles_[kMetaCF], base_meta_key.Encode(), &meta_value);
     if (s.ok()) {
       ParsedSetsMetaValue parsed_sets_meta_value(&meta_value);
       if (!parsed_sets_meta_value.IsStale() && parsed_sets_meta_value.Count() != 0) {
@@ -305,7 +313,7 @@ rocksdb::Status Redis::SDiffstore(const Slice& destination, const std::vector<st
 
   std::vector<std::string> members;
   BaseMetaKey base_meta_key0(keys[0]);
-  s = db_->Get(read_options, handles_[kSetsMetaCF], base_meta_key0.Encode(), &meta_value);
+  s = db_->Get(read_options, handles_[kMetaCF], base_meta_key0.Encode(), &meta_value);
   if (s.ok()) {
     ParsedSetsMetaValue parsed_sets_meta_value(&meta_value);
     if (!parsed_sets_meta_value.IsStale() && parsed_sets_meta_value.Count() != 0) {
@@ -344,7 +352,7 @@ rocksdb::Status Redis::SDiffstore(const Slice& destination, const std::vector<st
 
   uint32_t statistic = 0;
   BaseMetaKey base_destination(destination);
-  s = db_->Get(read_options, handles_[kSetsMetaCF], base_destination.Encode(), &meta_value);
+  s = db_->Get(read_options, handles_[kMetaCF], base_destination.Encode(), &meta_value);
   if (s.ok()) {
     ParsedSetsMetaValue parsed_sets_meta_value(&meta_value);
     statistic = parsed_sets_meta_value.Count();
@@ -353,13 +361,13 @@ rocksdb::Status Redis::SDiffstore(const Slice& destination, const std::vector<st
       return Status::InvalidArgument("set size overflow");
     }
     parsed_sets_meta_value.SetCount(static_cast<int32_t>(members.size()));
-    batch.Put(handles_[kSetsMetaCF], base_destination.Encode(), meta_value);
+    batch.Put(handles_[kMetaCF], base_destination.Encode(), meta_value);
   } else if (s.IsNotFound()) {
     char str[4];
     EncodeFixed32(str, members.size());
     SetsMetaValue sets_meta_value(Slice(str, sizeof(int32_t)));
     version = sets_meta_value.UpdateVersion();
-    batch.Put(handles_[kSetsMetaCF], base_destination.Encode(), sets_meta_value.Encode());
+    batch.Put(handles_[kMetaCF], base_destination.Encode(), sets_meta_value.Encode());
   } else {
     return s;
   }
@@ -392,7 +400,7 @@ rocksdb::Status Redis::SInter(const std::vector<std::string>& keys, std::vector<
 
   for (uint32_t idx = 1; idx < keys.size(); ++idx) {
     BaseMetaKey base_meta_key(keys[idx]);
-    s = db_->Get(read_options, handles_[kSetsMetaCF], base_meta_key.Encode(), &meta_value);
+    s = db_->Get(read_options, handles_[kMetaCF], base_meta_key.Encode(), &meta_value);
     if (s.ok()) {
       ParsedSetsMetaValue parsed_sets_meta_value(&meta_value);
       if (parsed_sets_meta_value.IsStale() || parsed_sets_meta_value.Count() == 0) {
@@ -408,7 +416,7 @@ rocksdb::Status Redis::SInter(const std::vector<std::string>& keys, std::vector<
   }
 
   BaseMetaKey base_meta_key0(keys[0]);
-  s = db_->Get(read_options, handles_[kSetsMetaCF], base_meta_key0.Encode(), &meta_value);
+  s = db_->Get(read_options, handles_[kMetaCF], base_meta_key0.Encode(), &meta_value);
   if (s.ok()) {
     ParsedSetsMetaValue parsed_sets_meta_value(&meta_value);
     if (parsed_sets_meta_value.IsStale() || parsed_sets_meta_value.Count() == 0) {
@@ -474,7 +482,7 @@ rocksdb::Status Redis::SInterstore(const Slice& destination, const std::vector<s
 
   for (uint32_t idx = 1; idx < keys.size(); ++idx) {
     BaseMetaKey base_meta_key(keys[idx]);
-    s = db_->Get(read_options, handles_[kSetsMetaCF], base_meta_key.Encode(), &meta_value);
+    s = db_->Get(read_options, handles_[kMetaCF], base_meta_key.Encode(), &meta_value);
     if (s.ok()) {
       ParsedSetsMetaValue parsed_sets_meta_value(&meta_value);
       if (parsed_sets_meta_value.IsStale() || parsed_sets_meta_value.Count() == 0) {
@@ -494,7 +502,7 @@ rocksdb::Status Redis::SInterstore(const Slice& destination, const std::vector<s
   std::vector<std::string> members;
   if (!have_invalid_sets) {
     BaseMetaKey base_meta_key0(keys[0]);
-    s = db_->Get(read_options, handles_[kSetsMetaCF], base_meta_key0.Encode(), &meta_value);
+    s = db_->Get(read_options, handles_[kMetaCF], base_meta_key0.Encode(), &meta_value);
     if (s.ok()) {
       ParsedSetsMetaValue parsed_sets_meta_value(&meta_value);
       if (parsed_sets_meta_value.IsStale() || parsed_sets_meta_value.Count() == 0) {
@@ -539,7 +547,7 @@ rocksdb::Status Redis::SInterstore(const Slice& destination, const std::vector<s
 
   uint32_t statistic = 0;
   BaseMetaKey base_destination(destination);
-  s = db_->Get(read_options, handles_[kSetsMetaCF], base_destination.Encode(), &meta_value);
+  s = db_->Get(read_options, handles_[kMetaCF], base_destination.Encode(), &meta_value);
   if (s.ok()) {
     ParsedSetsMetaValue parsed_sets_meta_value(&meta_value);
     statistic = parsed_sets_meta_value.Count();
@@ -548,13 +556,13 @@ rocksdb::Status Redis::SInterstore(const Slice& destination, const std::vector<s
       return Status::InvalidArgument("set size overflow");
     }
     parsed_sets_meta_value.SetCount(static_cast<int32_t>(members.size()));
-    batch.Put(handles_[kSetsMetaCF], base_destination.Encode(), meta_value);
+    batch.Put(handles_[kMetaCF], base_destination.Encode(), meta_value);
   } else if (s.IsNotFound()) {
     char str[4];
     EncodeFixed32(str, members.size());
     SetsMetaValue sets_meta_value(Slice(str, sizeof(int32_t)));
     version = sets_meta_value.UpdateVersion();
-    batch.Put(handles_[kSetsMetaCF], base_destination.Encode(), sets_meta_value.Encode());
+    batch.Put(handles_[kMetaCF], base_destination.Encode(), sets_meta_value.Encode());
   } else {
     return s;
   }
@@ -581,7 +589,7 @@ rocksdb::Status Redis::SIsmember(const Slice& key, const Slice& member, int32_t*
   read_options.snapshot = snapshot;
 
   BaseMetaKey base_meta_key(key);
-  rocksdb::Status s = db_->Get(read_options, handles_[kSetsMetaCF], base_meta_key.Encode(), &meta_value);
+  rocksdb::Status s = db_->Get(read_options, handles_[kMetaCF], base_meta_key.Encode(), &meta_value);
   if (s.ok()) {
     ParsedSetsMetaValue parsed_sets_meta_value(&meta_value);
     if (parsed_sets_meta_value.IsStale()) {
@@ -611,7 +619,7 @@ rocksdb::Status Redis::SMembers(const Slice& key, std::vector<std::string>* memb
   read_options.snapshot = snapshot;
 
   BaseMetaKey base_meta_key(key);
-  rocksdb::Status s = db_->Get(read_options, handles_[kSetsMetaCF], base_meta_key.Encode(), &meta_value);
+  rocksdb::Status s = db_->Get(read_options, handles_[kMetaCF], base_meta_key.Encode(), &meta_value);
   if (s.ok()) {
     ParsedSetsMetaValue parsed_sets_meta_value(&meta_value);
     if (parsed_sets_meta_value.IsStale()) {
@@ -643,7 +651,7 @@ Status Redis::SMembersWithTTL(const Slice& key, std::vector<std::string>* member
   ScopeSnapshot ss(db_, &snapshot);
   read_options.snapshot = snapshot;
   BaseMetaKey base_meta_key(key);
-  rocksdb::Status s = db_->Get(read_options, handles_[kSetsMetaCF], base_meta_key.Encode(), &meta_value);
+  rocksdb::Status s = db_->Get(read_options, handles_[kMetaCF], base_meta_key.Encode(), &meta_value);
   if (s.ok()) {
     ParsedSetsMetaValue parsed_sets_meta_value(&meta_value);
     if (parsed_sets_meta_value.Count() == 0) {
@@ -693,7 +701,7 @@ rocksdb::Status Redis::SMove(const Slice& source, const Slice& destination, cons
   }
 
   BaseMetaKey base_source(source);
-  rocksdb::Status s = db_->Get(default_read_options_, handles_[kSetsMetaCF], base_source.Encode(), &meta_value);
+  rocksdb::Status s = db_->Get(default_read_options_, handles_[kMetaCF], base_source.Encode(), &meta_value);
   if (s.ok()) {
     ParsedSetsMetaValue parsed_sets_meta_value(&meta_value);
     if (parsed_sets_meta_value.IsStale()) {
@@ -711,7 +719,7 @@ rocksdb::Status Redis::SMove(const Slice& source, const Slice& destination, cons
           return Status::InvalidArgument("set size overflow");
         }
         parsed_sets_meta_value.ModifyCount(-1);
-        batch.Put(handles_[kSetsMetaCF], base_source.Encode(), meta_value);
+        batch.Put(handles_[kMetaCF], base_source.Encode(), meta_value);
         batch.Delete(handles_[kSetsDataCF], sets_member_key.Encode());
         statistic++;
       } else if (s.IsNotFound()) {
@@ -729,13 +737,13 @@ rocksdb::Status Redis::SMove(const Slice& source, const Slice& destination, cons
   }
 
   BaseMetaKey base_destination(destination);
-  s = db_->Get(default_read_options_, handles_[kSetsMetaCF], base_destination.Encode(), &meta_value);
+  s = db_->Get(default_read_options_, handles_[kMetaCF], base_destination.Encode(), &meta_value);
   if (s.ok()) {
     ParsedSetsMetaValue parsed_sets_meta_value(&meta_value);
     if (parsed_sets_meta_value.IsStale() || parsed_sets_meta_value.Count() == 0) {
       version = parsed_sets_meta_value.InitialMetaValue();
       parsed_sets_meta_value.SetCount(1);
-      batch.Put(handles_[kSetsMetaCF], base_destination.Encode(), meta_value);
+      batch.Put(handles_[kMetaCF], base_destination.Encode(), meta_value);
       SetsMemberKey sets_member_key(destination, version, member);
       BaseDataValue i_val(Slice{});
       batch.Put(handles_[kSetsDataCF], sets_member_key.Encode(), i_val.Encode());
@@ -750,7 +758,7 @@ rocksdb::Status Redis::SMove(const Slice& source, const Slice& destination, cons
         }
         parsed_sets_meta_value.ModifyCount(1);
         BaseDataValue iter_value(Slice{});
-        batch.Put(handles_[kSetsMetaCF], base_destination.Encode(), meta_value);
+        batch.Put(handles_[kMetaCF], base_destination.Encode(), meta_value);
         batch.Put(handles_[kSetsDataCF], sets_member_key.Encode(), iter_value.Encode());
       } else if (!s.ok()) {
         return s;
@@ -761,7 +769,7 @@ rocksdb::Status Redis::SMove(const Slice& source, const Slice& destination, cons
     EncodeFixed32(str, 1);
     SetsMetaValue sets_meta_value(Slice(str, sizeof(int32_t)));
     version = sets_meta_value.UpdateVersion();
-    batch.Put(handles_[kSetsMetaCF], base_destination.Encode(), sets_meta_value.Encode());
+    batch.Put(handles_[kMetaCF], base_destination.Encode(), sets_meta_value.Encode());
     SetsMemberKey sets_member_key(destination, version, member);
     BaseDataValue iter_value(Slice{});
     batch.Put(handles_[kSetsDataCF], sets_member_key.Encode(), iter_value.Encode());
@@ -783,7 +791,7 @@ rocksdb::Status Redis::SPop(const Slice& key, std::vector<std::string>* members,
   uint64_t start_us = pstd::NowMicros();
 
   BaseMetaKey base_meta_key(key);
-  Status s = db_->Get(default_read_options_, handles_[kSetsMetaCF], base_meta_key.Encode(), &meta_value);
+  Status s = db_->Get(default_read_options_, handles_[kMetaCF], base_meta_key.Encode(), &meta_value);
   if (s.ok()) {
     ParsedSetsMetaValue parsed_sets_meta_value(&meta_value);
     if (parsed_sets_meta_value.IsStale()) {
@@ -806,8 +814,8 @@ rocksdb::Status Redis::SPop(const Slice& key, std::vector<std::string>* members,
         }
 
         // parsed_sets_meta_value.ModifyCount(-cnt);
-        // batch.Put(handles_[kSetsMetaCF], key, meta_value);
-        batch.Delete(handles_[kSetsMetaCF], base_meta_key.Encode());
+        // batch.Put(handles_[kMetaCF], key, meta_value);
+        batch.Delete(handles_[kMetaCF], base_meta_key.Encode());
         delete iter;
 
       } else {
@@ -847,7 +855,7 @@ rocksdb::Status Redis::SPop(const Slice& key, std::vector<std::string>* members,
           return Status::InvalidArgument("set size overflow");
         }
         parsed_sets_meta_value.ModifyCount(static_cast<int32_t>(-cnt));
-        batch.Put(handles_[kSetsMetaCF], base_meta_key.Encode(), meta_value);
+        batch.Put(handles_[kMetaCF], base_meta_key.Encode(), meta_value);
         delete iter;
       }
     }
@@ -883,7 +891,7 @@ rocksdb::Status Redis::SRandmember(const Slice& key, int32_t count, std::vector<
   std::unordered_set<int32_t> unique;
 
   BaseMetaKey base_meta_key(key);
-  rocksdb::Status s = db_->Get(default_read_options_, handles_[kSetsMetaCF], base_meta_key.Encode(), &meta_value);
+  rocksdb::Status s = db_->Get(default_read_options_, handles_[kMetaCF], base_meta_key.Encode(), &meta_value);
   if (s.ok()) {
     ParsedSetsMetaValue parsed_sets_meta_value(&meta_value);
     if (parsed_sets_meta_value.IsStale()) {
@@ -947,7 +955,7 @@ rocksdb::Status Redis::SRem(const Slice& key, const std::vector<std::string>& me
   std::string meta_value;
 
   BaseMetaKey base_meta_key(key);
-  rocksdb::Status s = db_->Get(default_read_options_, handles_[kSetsMetaCF], base_meta_key.Encode(), &meta_value);
+  rocksdb::Status s = db_->Get(default_read_options_, handles_[kMetaCF], base_meta_key.Encode(), &meta_value);
   if (s.ok()) {
     ParsedSetsMetaValue parsed_sets_meta_value(&meta_value);
     if (parsed_sets_meta_value.IsStale()) {
@@ -975,7 +983,7 @@ rocksdb::Status Redis::SRem(const Slice& key, const std::vector<std::string>& me
         return Status::InvalidArgument("set size overflow");
       }
       parsed_sets_meta_value.ModifyCount(-cnt);
-      batch.Put(handles_[kSetsMetaCF], base_meta_key.Encode(), meta_value);
+      batch.Put(handles_[kMetaCF], base_meta_key.Encode(), meta_value);
     }
   } else if (s.IsNotFound()) {
     *ret = 0;
@@ -1004,7 +1012,7 @@ rocksdb::Status Redis::SUnion(const std::vector<std::string>& keys, std::vector<
 
   for (const auto& key : keys) {
     BaseMetaKey base_meta_key(key);
-    s = db_->Get(read_options, handles_[kSetsMetaCF], base_meta_key.Encode(), &meta_value);
+    s = db_->Get(read_options, handles_[kMetaCF], base_meta_key.Encode(), &meta_value);
     if (s.ok()) {
       ParsedSetsMetaValue parsed_sets_meta_value(&meta_value);
       if (!parsed_sets_meta_value.IsStale() && parsed_sets_meta_value.Count() != 0) {
@@ -1055,7 +1063,7 @@ rocksdb::Status Redis::SUnionstore(const Slice& destination, const std::vector<s
 
   for (const auto& key : keys) {
     BaseMetaKey base_meta_key(key);
-    s = db_->Get(read_options, handles_[kSetsMetaCF], base_meta_key.Encode(), &meta_value);
+    s = db_->Get(read_options, handles_[kMetaCF], base_meta_key.Encode(), &meta_value);
     if (s.ok()) {
       ParsedSetsMetaValue parsed_sets_meta_value(&meta_value);
       if (!parsed_sets_meta_value.IsStale() && parsed_sets_meta_value.Count() != 0) {
@@ -1087,7 +1095,7 @@ rocksdb::Status Redis::SUnionstore(const Slice& destination, const std::vector<s
 
   uint32_t statistic = 0;
   BaseMetaKey base_destination(destination);
-  s = db_->Get(read_options, handles_[kSetsMetaCF], base_destination.Encode(), &meta_value);
+  s = db_->Get(read_options, handles_[kMetaCF], base_destination.Encode(), &meta_value);
   if (s.ok()) {
     ParsedSetsMetaValue parsed_sets_meta_value(&meta_value);
     statistic = parsed_sets_meta_value.Count();
@@ -1096,13 +1104,13 @@ rocksdb::Status Redis::SUnionstore(const Slice& destination, const std::vector<s
       return Status::InvalidArgument("set size overflow");
     }
     parsed_sets_meta_value.SetCount(static_cast<int32_t>(members.size()));
-    batch.Put(handles_[kSetsMetaCF], destination, meta_value);
+    batch.Put(handles_[kMetaCF], destination, meta_value);
   } else if (s.IsNotFound()) {
     char str[4];
     EncodeFixed32(str, members.size());
     SetsMetaValue sets_meta_value(Slice(str, sizeof(int32_t)));
     version = sets_meta_value.UpdateVersion();
-    batch.Put(handles_[kSetsMetaCF], base_destination.Encode(), sets_meta_value.Encode());
+    batch.Put(handles_[kMetaCF], base_destination.Encode(), sets_meta_value.Encode());
   } else {
     return s;
   }
@@ -1137,7 +1145,7 @@ rocksdb::Status Redis::SScan(const Slice& key, int64_t cursor, const std::string
   read_options.snapshot = snapshot;
 
   BaseMetaKey base_meta_key(key);
-  rocksdb::Status s = db_->Get(read_options, handles_[kSetsMetaCF], base_meta_key.Encode(), &meta_value);
+  rocksdb::Status s = db_->Get(read_options, handles_[kMetaCF], base_meta_key.Encode(), &meta_value);
   if (s.ok()) {
     ParsedSetsMetaValue parsed_sets_meta_value(&meta_value);
     if (parsed_sets_meta_value.IsStale() || parsed_sets_meta_value.Count() == 0) {
@@ -1195,7 +1203,7 @@ rocksdb::Status Redis::SetsExpire(const Slice& key, uint64_t ttl) {
   ScopeRecordLock l(lock_mgr_, key);
 
   BaseMetaKey base_meta_key(key);
-  rocksdb::Status s = db_->Get(default_read_options_, handles_[kSetsMetaCF], base_meta_key.Encode(), &meta_value);
+  rocksdb::Status s = db_->Get(default_read_options_, handles_[kMetaCF], base_meta_key.Encode(), &meta_value);
   if (s.ok()) {
     ParsedSetsMetaValue parsed_sets_meta_value(&meta_value);
     if (parsed_sets_meta_value.IsStale()) {
@@ -1206,10 +1214,10 @@ rocksdb::Status Redis::SetsExpire(const Slice& key, uint64_t ttl) {
 
     if (ttl > 0) {
       parsed_sets_meta_value.SetRelativeTimestamp(ttl);
-      s = db_->Put(default_write_options_, handles_[kSetsMetaCF], base_meta_key.Encode(), meta_value);
+      s = db_->Put(default_write_options_, handles_[kMetaCF], base_meta_key.Encode(), meta_value);
     } else {
       parsed_sets_meta_value.InitialMetaValue();
-      s = db_->Put(default_write_options_, handles_[kSetsMetaCF], base_meta_key.Encode(), meta_value);
+      s = db_->Put(default_write_options_, handles_[kMetaCF], base_meta_key.Encode(), meta_value);
     }
   }
   return s;
@@ -1220,7 +1228,7 @@ rocksdb::Status Redis::SetsDel(const Slice& key) {
   ScopeRecordLock l(lock_mgr_, key);
 
   BaseMetaKey base_meta_key(key);
-  rocksdb::Status s = db_->Get(default_read_options_, handles_[kSetsMetaCF], base_meta_key.Encode(), &meta_value);
+  rocksdb::Status s = db_->Get(default_read_options_, handles_[kMetaCF], base_meta_key.Encode(), &meta_value);
   if (s.ok()) {
     ParsedSetsMetaValue parsed_sets_meta_value(&meta_value);
     if (parsed_sets_meta_value.IsStale()) {
@@ -1230,7 +1238,7 @@ rocksdb::Status Redis::SetsDel(const Slice& key) {
     } else {
       uint32_t statistic = parsed_sets_meta_value.Count();
       parsed_sets_meta_value.InitialMetaValue();
-      s = db_->Put(default_write_options_, handles_[kSetsMetaCF], base_meta_key.Encode(), meta_value);
+      s = db_->Put(default_write_options_, handles_[kMetaCF], base_meta_key.Encode(), meta_value);
       UpdateSpecificKeyStatistics(DataType::kSets, key.ToString(), statistic);
     }
   }
@@ -1242,7 +1250,7 @@ rocksdb::Status Redis::SetsExpireat(const Slice& key, uint64_t timestamp) {
   ScopeRecordLock l(lock_mgr_, key);
 
   BaseMetaKey base_meta_key(key);
-  rocksdb::Status s = db_->Get(default_read_options_, handles_[kSetsMetaCF], base_meta_key.Encode(), &meta_value);
+  rocksdb::Status s = db_->Get(default_read_options_, handles_[kMetaCF], base_meta_key.Encode(), &meta_value);
   if (s.ok()) {
     ParsedSetsMetaValue parsed_sets_meta_value(&meta_value);
     if (parsed_sets_meta_value.IsStale()) {
@@ -1255,7 +1263,7 @@ rocksdb::Status Redis::SetsExpireat(const Slice& key, uint64_t timestamp) {
       } else {
         parsed_sets_meta_value.InitialMetaValue();
       }
-      return db_->Put(default_write_options_, handles_[kSetsMetaCF], base_meta_key.Encode(), meta_value);
+      return db_->Put(default_write_options_, handles_[kMetaCF], base_meta_key.Encode(), meta_value);
     }
   }
   return s;
@@ -1266,7 +1274,7 @@ rocksdb::Status Redis::SetsPersist(const Slice& key) {
   ScopeRecordLock l(lock_mgr_, key);
 
   BaseMetaKey base_meta_key(key);
-  rocksdb::Status s = db_->Get(default_read_options_, handles_[kSetsMetaCF], base_meta_key.Encode(), &meta_value);
+  rocksdb::Status s = db_->Get(default_read_options_, handles_[kMetaCF], base_meta_key.Encode(), &meta_value);
   if (s.ok()) {
     ParsedSetsMetaValue parsed_sets_meta_value(&meta_value);
     if (parsed_sets_meta_value.IsStale()) {
@@ -1279,7 +1287,7 @@ rocksdb::Status Redis::SetsPersist(const Slice& key) {
         return rocksdb::Status::NotFound("Not have an associated timeout");
       } else {
         parsed_sets_meta_value.SetEtime(0);
-        return db_->Put(default_write_options_, handles_[kSetsMetaCF], base_meta_key.Encode(), meta_value);
+        return db_->Put(default_write_options_, handles_[kMetaCF], base_meta_key.Encode(), meta_value);
       }
     }
   }
@@ -1290,7 +1298,7 @@ rocksdb::Status Redis::SetsTTL(const Slice& key, uint64_t* timestamp) {
   std::string meta_value;
 
   BaseMetaKey base_meta_key(key);
-  rocksdb::Status s = db_->Get(default_read_options_, handles_[kSetsMetaCF], base_meta_key.Encode(), &meta_value);
+  rocksdb::Status s = db_->Get(default_read_options_, handles_[kMetaCF], base_meta_key.Encode(), &meta_value);
   if (s.ok()) {
     ParsedSetsMetaValue parsed_setes_meta_value(&meta_value);
     if (parsed_setes_meta_value.IsStale()) {
@@ -1324,7 +1332,7 @@ void Redis::ScanSets() {
   auto current_time = static_cast<int32_t>(time(nullptr));
 
   INFO("***************Sets Meta Data***************");
-  auto meta_iter = db_->NewIterator(iterator_options, handles_[kSetsMetaCF]);
+  auto meta_iter = db_->NewIterator(iterator_options, handles_[kMetaCF]);
   for (meta_iter->SeekToFirst(); meta_iter->Valid(); meta_iter->Next()) {
     ParsedSetsMetaValue parsed_sets_meta_value(meta_iter->value());
     ParsedBaseMetaKey parsed_meta_key(meta_iter->key());


### PR DESCRIPTION
# 背景

当前 `Pika` 的一个 `Key` 可以对应多种数据结构，和 `Redis` 不一致



## 解决方案

在 `Floyd` 现有的设计之上，再新增一个 `Column-Family` , 专门用于存放所有的 `Key` ，其对应的 `value` 为数据类型 `type`，并在内存中建立一个所有 `Key` 的 `cuckoo bloom filter`. 在增加一个 `Key` 时，先去读 `cuckoo bloom filter` 判断被增加的 `Key` 是否存在，如果不存在，则直接进行后续操作，如果存在，但可能是假阳性，所以需要一次读盘操作，去新增加的 `Column-Family` 中读取，验证被增加的 `Key` 是否真正存在，然后再进行后续的操作，单独设置 `block cache` ，为这个新增加的 `Column-Family` 单独设置一个，防止和别的数据共用，导致 `Key` 的 `Colunm-Family` 淘汰出内存

```cpp
修改前：
enum ColumnFamilyIndex {
    kStringsCF = 0,
    kHashesMetaCF = 1,
    kHashesDataCF = 2,
    kSetsMetaCF = 3,
    kSetsDataCF = 4,
    kListsMetaCF = 5,
    kListsDataCF = 6,
    kZsetsMetaCF = 7,
    kZsetsDataCF = 8,
    kZsetsScoreCF = 9,
    kStreamsMetaCF = 10,
    kStreamsDataCF = 11,
};

修改后：
enum ColumnFamilyIndex {
    kStringsCF = 0,
    kHashesDataCF = 1,
    kSetsDataCF = 2,
    kListsDataCF = 3,
    kZsetsDataCF = 4,
    kZsetsScoreCF = 5,
    kStreamsDataCF = 6,
    kMetaCF = 7,
};
```



## kMetaCF 字段设计

**String**

```
key格式
| reserve1 | key | reserve2 | 
|    8B    |     |   16B    |

value格式
| value | reserve | cdate | timestamp | 
|       |   16B   |   8B  |    8B     |
```

**Hash**

```
key格式
| reserve1 | key | reserve2 | 
|    8B    |     |    16B   |

value格式
| hash_size | version |  reserve  | cdate | timestamp | 
|    4B     |    8B   |    16B    |   8B  |     8B    |
```

**List**

```
key格式
| reserve1 | key | reserve2 |
|    8B    |     |   16B    |

value格式
|list_size| version | left index | right index | reserve |  cdate | timestamp | 
|   4B    |   8B    |     8B     |     8B      |   16B   |   8B   |    8B     |
```

**set**

```
key格式
| reserve1 | key | reserve2 |
|    8B    |     |    16B    |

value格式
| set_size | version | reserve | cdate | timestamp | 
|    4B    |    8B   |   16B   |   8B  |    8B     |
```

**zset**

```
key格式
| reserve1 | key | reserve2 |
|    8B    |     |    16B   |  

value格式
| zset_size | version | reserve  | cdate | timestamp | 
|    4B     |    8B   |    16B   |   8B  |    8B     |

```



**修改后**

我们对每一种数据类型的 `Meta` 的 `value` 前增加一个字段 `Type` 用于区别每个 `Key` 对应的数据结构

以 `Set` 类型举例

```
key格式
| reserve1 | key | reserve2 |
|    8B    |     |    16B   |

value格式
| type | set_size | version | reserve | cdate | timestamp | 
|  1B  |    4B    |    8B   |   16B   |   8B  |    8B     |
```

在解析的时候，先解析头部的第一个字节，然后根据类型判断是否需要继续解析下去