### PR TITLE
feat: add command object pool

### DIFF
--- a/src/base_cmd.cc
+++ b/src/base_cmd.cc
@@ -54,7 +54,6 @@ bool BaseCmd::HasFlag(uint32_t flag) const { return flag_ & flag; }
 void BaseCmd::SetFlag(uint32_t flag) { flag_ |= flag; }
 void BaseCmd::ResetFlag(uint32_t flag) { flag_ &= ~flag; }
 bool BaseCmd::HasSubCommand() const { return false; }
-BaseCmd* BaseCmd::GetSubCmd(const std::string& cmdName) { return nullptr; }
 uint32_t BaseCmd::AclCategory() const { return acl_category_; }
 void BaseCmd::AddAclCategory(uint32_t aclCategory) { acl_category_ |= aclCategory; }
 std::string BaseCmd::Name() const { return name_; }
@@ -67,22 +66,22 @@ uint32_t BaseCmd::GetCmdID() const { return cmd_id_; }
 BaseCmdGroup::BaseCmdGroup(const std::string& name, uint32_t flag) : BaseCmdGroup(name, -2, flag) {}
 BaseCmdGroup::BaseCmdGroup(const std::string& name, int16_t arity, uint32_t flag) : BaseCmd(name, arity, flag, 0) {}
 
-void BaseCmdGroup::AddSubCmd(std::unique_ptr<BaseCmd> cmd) { subCmds_[cmd->Name()] = std::move(cmd); }
-
-BaseCmd* BaseCmdGroup::GetSubCmd(const std::string& cmdName) {
-  auto subCmd = subCmds_.find(cmdName);
-  if (subCmd == subCmds_.end()) {
-    return nullptr;
-  }
-  return subCmd->second.get();
-}
+// void BaseCmdGroup::AddSubCmd(std::unique_ptr<BaseCmd> cmd) { subCmds_[cmd->Name()] = std::move(cmd); }
+//
+// BaseCmd* BaseCmdGroup::GetSubCmd(const std::string& cmdName) {
+//   auto subCmd = subCmds_.find(cmdName);
+//   if (subCmd == subCmds_.end()) {
+//     return nullptr;
+//   }
+//   return subCmd->second.get();
+// }
 
 bool BaseCmdGroup::DoInitial(PClient* client) {
   client->SetSubCmdName(client->argv_[1]);
-  if (!subCmds_.contains(client->SubCmdName())) {
-    client->SetRes(CmdRes::kSyntaxErr, client->argv_[0] + " unknown subcommand for '" + client->SubCmdName() + "'");
-    return false;
-  }
+  //  if (!subCmds_.contains(client->SubCmdName())) {
+  //    client->SetRes(CmdRes::kSyntaxErr, client->argv_[0] + " unknown subcommand for '" + client->SubCmdName() + "'");
+  //    return false;
+  //  }
   return true;
 }
 

--- a/src/base_cmd.h
+++ b/src/base_cmd.h
@@ -275,7 +275,6 @@ class BaseCmd : public std::enable_shared_from_this<BaseCmd> {
   // If it is a subcommand, you need to implement these functions
   // e.g: CmdConfig is a subcommand, and the subcommand is set and get
   virtual bool HasSubCommand() const;  // The command is there a sub command
-  virtual BaseCmd* GetSubCmd(const std::string& cmdName);
 
   uint32_t AclCategory() const;
   void AddAclCategory(uint32_t aclCategory);
@@ -329,16 +328,11 @@ class BaseCmdGroup : public BaseCmd {
 
   ~BaseCmdGroup() override = default;
 
-  void AddSubCmd(std::unique_ptr<BaseCmd> cmd);
-  BaseCmd* GetSubCmd(const std::string& cmdName) override;
-
   // group cmd this function will not be called
   void DoCmd(PClient* client) override{};
 
   // group cmd this function will not be called
   bool DoInitial(PClient* client) override;
-
- private:
-  std::map<std::string, std::unique_ptr<BaseCmd>> subCmds_;
 };
+
 }  // namespace pikiwidb

--- a/src/cmd_admin.cc
+++ b/src/cmd_admin.cc
@@ -11,23 +11,23 @@
 
 namespace pikiwidb {
 
-CmdConfig::CmdConfig(const std::string& name, int arity) : BaseCmdGroup(name, kCmdFlagsAdmin, kAclCategoryAdmin) {}
+ConfigCmd::ConfigCmd(const std::string& name, int arity) : BaseCmdGroup(name, kCmdFlagsAdmin, kAclCategoryAdmin) {}
 
-bool CmdConfig::HasSubCommand() const { return true; }
+bool ConfigCmd::HasSubCommand() const { return true; }
 
-CmdConfigGet::CmdConfigGet(const std::string& name, int16_t arity)
+ConfigGetCmd::ConfigGetCmd(const std::string& name, int16_t arity)
     : BaseCmd(name, arity, kCmdFlagsAdmin | kCmdFlagsWrite, kAclCategoryAdmin) {}
 
-bool CmdConfigGet::DoInitial(PClient* client) { return true; }
+bool ConfigGetCmd::DoInitial(PClient* client) { return true; }
 
-void CmdConfigGet::DoCmd(PClient* client) { client->AppendString("config cmd in development"); }
+void ConfigGetCmd::DoCmd(PClient* client) { client->AppendString("config cmd in development"); }
 
-CmdConfigSet::CmdConfigSet(const std::string& name, int16_t arity)
+ConfigSetCmd::ConfigSetCmd(const std::string& name, int16_t arity)
     : BaseCmd(name, arity, kCmdFlagsAdmin, kAclCategoryAdmin) {}
 
-bool CmdConfigSet::DoInitial(PClient* client) { return true; }
+bool ConfigSetCmd::DoInitial(PClient* client) { return true; }
 
-void CmdConfigSet::DoCmd(PClient* client) { client->AppendString("config cmd in development"); }
+void ConfigSetCmd::DoCmd(PClient* client) { client->AppendString("config cmd in development"); }
 
 FlushdbCmd::FlushdbCmd(const std::string& name, int16_t arity)
     : BaseCmd(name, arity, kCmdFlagsAdmin | kCmdFlagsWrite, kAclCategoryWrite | kAclCategoryAdmin) {}

--- a/src/cmd_admin.h
+++ b/src/cmd_admin.h
@@ -14,9 +14,9 @@ namespace pikiwidb {
 
 extern PConfig g_config;
 
-class CmdConfig : public BaseCmdGroup {
+class ConfigCmd : public BaseCmdGroup {
  public:
-  CmdConfig(const std::string& name, int arity);
+  ConfigCmd(const std::string& name, int arity);
 
   bool HasSubCommand() const override;
 
@@ -24,14 +24,12 @@ class CmdConfig : public BaseCmdGroup {
   bool DoInitial(PClient* client) override { return true; };
 
  private:
-  //  std::vector<std::string> subCmd_;
-
   void DoCmd(PClient* client) override{};
 };
 
-class CmdConfigGet : public BaseCmd {
+class ConfigGetCmd : public BaseCmd {
  public:
-  CmdConfigGet(const std::string& name, int16_t arity);
+  ConfigGetCmd(const std::string& name, int16_t arity);
 
  protected:
   bool DoInitial(PClient* client) override;
@@ -40,9 +38,9 @@ class CmdConfigGet : public BaseCmd {
   void DoCmd(PClient* client) override;
 };
 
-class CmdConfigSet : public BaseCmd {
+class ConfigSetCmd : public BaseCmd {
  public:
-  CmdConfigSet(const std::string& name, int16_t arity);
+  ConfigSetCmd(const std::string& name, int16_t arity);
 
  protected:
   bool DoInitial(PClient* client) override;

--- a/src/cmd_object_pool.cc
+++ b/src/cmd_object_pool.cc
@@ -49,10 +49,14 @@ void CmdObjectPool::InitCommand() {
   ADD_COMMAND(Flushdb, 1);
   ADD_COMMAND(Flushall, 1);
   ADD_COMMAND(Select, 2);
+  ADD_COMMAND(Shutdown, 1);
 
   // keyspace
   ADD_COMMAND(Del, -2);
   ADD_COMMAND(Exists, -2);
+  ADD_COMMAND(Type, 2);
+  ADD_COMMAND(Expire, 3);
+  ADD_COMMAND(Ttl, 2);
   ADD_COMMAND(PExpire, 3);
   ADD_COMMAND(Expireat, 3);
   ADD_COMMAND(PExpireat, 3);
@@ -117,6 +121,7 @@ void CmdObjectPool::InitCommand() {
   ADD_COMMAND(SMembers, 2);
   ADD_COMMAND(SDiff, -2);
   ADD_COMMAND(SDiffstore, -3);
+  ADD_COMMAND(SScan, -3);
 
   // list
   ADD_COMMAND(LPush, -3);

--- a/src/cmd_object_pool.cc
+++ b/src/cmd_object_pool.cc
@@ -27,7 +27,7 @@ namespace pikiwidb {
   } while (0)
 
 // subcommand name is baseCmdName + subCmdName
-//  for example: ConfigGetCmd is the subcommand of configGet
+// for example: ConfigGetCmd is the subcommand of configGet
 #define ADD_SUB_COMMAND(group, subCmd, argc)                                                                       \
   do {                                                                                                             \
     g_pikiwidb->GetCmdObjectPool()->SetNewObjectFunc(kCmdName##group + #subCmd, []() -> std::unique_ptr<BaseCmd> { \

--- a/src/cmd_object_pool.cc
+++ b/src/cmd_object_pool.cc
@@ -1,0 +1,267 @@
+/*
+ * Copyright (c) 2023-present, Qihoo, Inc.  All rights reserved.
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+#include "cmd_object_pool.h"
+#include "base_cmd.h"
+#include "cmd_admin.h"
+#include "cmd_hash.h"
+#include "cmd_keys.h"
+#include "cmd_kv.h"
+#include "cmd_list.h"
+#include "cmd_set.h"
+#include "cmd_zset.h"
+#include "pikiwidb.h"
+
+extern std::unique_ptr<PikiwiDB> g_pikiwidb;
+
+namespace pikiwidb {
+
+#define ADD_COMMAND(cmd, argc)                                                                                        \
+  do {                                                                                                                \
+    g_pikiwidb->GetCmdObjectPool()->SetNewObjectFunc(                                                                 \
+        kCmdName##cmd, []() -> std::unique_ptr<BaseCmd> { return std::make_unique<cmd##Cmd>(kCmdName##cmd, argc); }); \
+  } while (0)
+
+// subcommand name is baseCmdName + subCmdName
+//  for example: ConfigGetCmd is the subcommand of configGet
+#define ADD_SUB_COMMAND(group, subCmd, argc)                                                                       \
+  do {                                                                                                             \
+    g_pikiwidb->GetCmdObjectPool()->SetNewObjectFunc(kCmdName##group + #subCmd, []() -> std::unique_ptr<BaseCmd> { \
+      return std::make_unique<group##subCmd##Cmd>(kCmdName##group + #subCmd, argc);                                \
+    });                                                                                                            \
+  } while (0)
+
+void CmdObjectPool::InitCommand() {
+  // admin
+  ADD_COMMAND(Config, -2);
+  ADD_SUB_COMMAND(Config, Get, -3);
+  ADD_SUB_COMMAND(Config, Set, -4);
+
+  // server
+  ADD_COMMAND(Flushdb, 1);
+  ADD_COMMAND(Flushall, 1);
+  ADD_COMMAND(Select, 2);
+
+  // keyspace
+  ADD_COMMAND(Del, -2);
+  ADD_COMMAND(Exists, -2);
+  ADD_COMMAND(PExpire, 3);
+  ADD_COMMAND(Expireat, 3);
+  ADD_COMMAND(PExpireat, 3);
+  ADD_COMMAND(Pttl, 2);
+  ADD_COMMAND(Persist, 2);
+  ADD_COMMAND(Keys, 2);
+
+  // kv
+  ADD_COMMAND(Get, 2);
+  ADD_COMMAND(Set, -3);
+  ADD_COMMAND(MGet, -2);
+  ADD_COMMAND(MSet, -3);
+  ADD_COMMAND(GetSet, 3);
+  ADD_COMMAND(SetNX, 3);
+  ADD_COMMAND(Append, 3);
+  ADD_COMMAND(Strlen, 2);
+  ADD_COMMAND(Incr, 2);
+  ADD_COMMAND(Incrby, 3);
+  ADD_COMMAND(Decrby, 3);
+  ADD_COMMAND(IncrbyFloat, 3);
+  ADD_COMMAND(SetEx, 4);
+  ADD_COMMAND(PSetEx, 4);
+  ADD_COMMAND(BitOp, -4);
+  ADD_COMMAND(BitCount, -2);
+  ADD_COMMAND(GetBit, 3);
+  ADD_COMMAND(GetRange, 4);
+  ADD_COMMAND(SetRange, 4);
+  ADD_COMMAND(Decr, 2);
+  ADD_COMMAND(SetBit, 4);
+  ADD_COMMAND(MSetnx, -3);
+
+  // hash
+  ADD_COMMAND(HSet, -4);
+  ADD_COMMAND(HGet, 3);
+  ADD_COMMAND(HDel, -3);
+  ADD_COMMAND(HMSet, -4);
+  ADD_COMMAND(HMGet, -3);
+  ADD_COMMAND(HGetAll, 2);
+  ADD_COMMAND(HKeys, 2);
+  ADD_COMMAND(HLen, 2);
+  ADD_COMMAND(HStrLen, 3);
+  ADD_COMMAND(HScan, -3);
+  ADD_COMMAND(HVals, 2);
+  ADD_COMMAND(HIncrbyFloat, 4);
+  ADD_COMMAND(HSetNX, 4);
+  ADD_COMMAND(HIncrby, 4);
+  ADD_COMMAND(HRandField, -2);
+  ADD_COMMAND(HExists, 3);
+
+  // set
+  ADD_COMMAND(SIsMember, 3);
+  ADD_COMMAND(SAdd, -3);
+  ADD_COMMAND(SUnionStore, -3);
+  ADD_COMMAND(SRem, -3);
+  ADD_COMMAND(SInter, -2);
+  ADD_COMMAND(SUnion, -2);
+  ADD_COMMAND(SInterStore, -3);
+  ADD_COMMAND(SCard, 2);
+  ADD_COMMAND(SMove, 4);
+  ADD_COMMAND(SRandMember, -2);  // Added the count argument since Redis 3.2.0
+  ADD_COMMAND(SPop, -2);
+  ADD_COMMAND(SMembers, 2);
+  ADD_COMMAND(SDiff, -2);
+  ADD_COMMAND(SDiffstore, -3);
+
+  // list
+  ADD_COMMAND(LPush, -3);
+  ADD_COMMAND(RPush, -3);
+  ADD_COMMAND(RPop, 2);
+  ADD_COMMAND(LRem, 4);
+  ADD_COMMAND(LRange, 4);
+  ADD_COMMAND(LTrim, 4);
+  ADD_COMMAND(LSet, 4);
+  ADD_COMMAND(LInsert, 5);
+  ADD_COMMAND(LPushx, -3);
+  ADD_COMMAND(RPushx, -3);
+  ADD_COMMAND(LPop, 2);
+  ADD_COMMAND(LIndex, 3);
+  ADD_COMMAND(LLen, 2);
+
+  // zset
+  ADD_COMMAND(ZAdd, -4);
+  ADD_COMMAND(ZRevrange, -4);
+  ADD_COMMAND(ZRangebyscore, -4);
+  ADD_COMMAND(ZRemrangebyscore, 4);
+  ADD_COMMAND(ZRemrangebyrank, 4);
+  ADD_COMMAND(ZRevrangebyscore, -4);
+  ADD_COMMAND(ZCard, 2);
+  ADD_COMMAND(ZScore, 3);
+  ADD_COMMAND(ZRange, -4);
+  ADD_COMMAND(ZRangebylex, -3);
+  ADD_COMMAND(ZRevrangebylex, -3);
+  ADD_COMMAND(ZRank, 3);
+  ADD_COMMAND(ZRevrank, 3);
+  ADD_COMMAND(ZRem, -3);
+  ADD_COMMAND(ZIncrby, 4);
+}
+
+void CmdObjectPool::InitObjectPool() {
+  for (const auto &object : create_object_) {
+    pool_.emplace(object.first, object.second());
+  }
+}
+
+std::unique_ptr<BaseCmd> pikiwidb::CmdObjectPool::GetObject(const std::string &key) {
+  for (auto &obj : *local_pool) {
+    if (obj.key_ == key && obj.object_) {
+      return std::move(obj.object_);
+    }
+  }
+
+  // if you don t find it go to the global search
+  return GetObjectByGlobal(key);
+}
+void CmdObjectPool::PutObject(std::string &&key, std::unique_ptr<BaseCmd> &&v) {
+  //  std::cout << std::this_thread::get_id() << " >> " << (&local_pool) << std::endl;
+  ++counter;
+  if (counter == 0) {
+    // If the version number reaches 0, reset all version numbers in localPool
+    for (auto &obj : *local_pool) {
+      obj.version_ = 0;
+    }
+    return;
+  }
+
+  bool needPush = true;
+  for (auto &obj : *local_pool) {
+    if (obj.key_ == key && !obj.object_) {
+      // if the keys are the same and the pointer is empty
+      obj.version_ = counter;
+      obj.object_ = std::move(v);
+      needPush = false;
+      break;
+    }
+  }
+
+  if (needPush) {
+    // put the used object back into localPool
+    local_pool->emplace_back(counter, std::move(key), std::move(v));
+  }
+
+  if (counter % check_rate_ != 0 || local_pool->size() <= local_max_) {
+    return;
+  }
+
+  // The version number is sorted from largest to smallest
+  std::sort(local_pool->begin(), local_pool->end(),
+            [](const SmallObject &a, const SmallObject &b) { return a.version_ > b.version_; });
+
+  //  std::cout << "-------------------------------------------" << std::endl;
+  //  for (const auto &smallObj : *localPool) {
+  //    std::cout << "!!" << smallObj.key_ << "!!" << std::endl;
+  //  }
+
+  // delete the last few
+  for (auto it = local_pool->rbegin(); it != local_pool->rend();) {
+    PutObjectBackGlobal(it->key_, it->object_);
+    it = std::vector<SmallObject>::reverse_iterator(local_pool->erase((++it).base()));
+
+    //    std::cout << "smallPool.size:" << local_pool->size() << " smallPool.cap:" << local_pool->capacity() <<
+    //    std::endl;
+    if (local_pool->size() <= local_max_) {
+      break;
+    }
+  }
+
+  // debug打印
+  //  for (const auto &smallObj : *localPool) {
+  //    std::cout << "!!" << smallObj.key_ << "!!" << std::endl;
+  //  }
+  //  std::cout << "-------------------------------------------" << std::endl;
+}
+
+std::unique_ptr<BaseCmd> CmdObjectPool::GetObjectByGlobal(const std::string &key) {
+  std::lock_guard l(mutex_);
+  auto it = pool_.find(key);
+  if (it != pool_.end()) {
+    std::unique_ptr<BaseCmd> obj = std::move(it->second);
+    pool_.erase(it);
+    return obj;
+  }
+
+  // If you can't find it, use the func function to create a corresponding object
+  auto func = create_object_.find(key);
+  if (func == create_object_.end()) {
+    return nullptr;
+  }
+  return func->second();
+}
+
+void CmdObjectPool::PutObjectBackGlobal(const std::string &key, std::unique_ptr<BaseCmd> &v) {
+  std::lock_guard l(mutex_);
+  pool_[key] = std::move(v);
+}
+
+std::pair<std::unique_ptr<BaseCmd>, CmdRes::CmdRet> CmdObjectPool::GetCommand(const std::string &cmdName,
+                                                                              PClient *client) {
+  auto cmd = GetObject(cmdName);
+  if (cmd == nullptr) {
+    return std::pair(nullptr, CmdRes::kSyntaxErr);
+  }
+
+  if (cmd->HasSubCommand()) {
+    if (client->argv_.size() < 2) {
+      return std::pair(nullptr, CmdRes::kInvalidParameter);
+    }
+    auto subCmd = GetObject(cmdName + ProcessSubcommandName(client->argv_[1]));
+    return std::pair(std::move(subCmd), CmdRes::kSyntaxErr);
+  }
+  return std::pair(std::move(cmd), CmdRes::kSyntaxErr);
+}
+
+thread_local std::unique_ptr<std::vector<SmallObject>> CmdObjectPool::local_pool = nullptr;
+thread_local uint64_t CmdObjectPool::counter = 0;
+
+}  // namespace pikiwidb

--- a/src/cmd_object_pool.h
+++ b/src/cmd_object_pool.h
@@ -17,6 +17,8 @@ namespace pikiwidb {
 
 struct SmallObject {
   // Version, after each use, a new version number is assigned
+  SmallObject(uint64_t version, std::string key, std::unique_ptr<BaseCmd> object)
+      : version_(version), key_(std::move(key)), object_(std::move(object)) {}
   uint64_t version_;
   std::string key_;
   std::unique_ptr<BaseCmd> object_;

--- a/src/cmd_object_pool.h
+++ b/src/cmd_object_pool.h
@@ -18,8 +18,8 @@ namespace pikiwidb {
 struct SmallObject {
   // Version, after each use, a new version number is assigned
   SmallObject(uint64_t version, std::string key, std::unique_ptr<BaseCmd> object)
-      : version_(version), key_(std::move(key)), object_(std::move(object)) {}
-  uint64_t version_;
+      : count_(version), key_(std::move(key)), object_(std::move(object)) {}
+  uint64_t count_;
   std::string key_;
   std::unique_ptr<BaseCmd> object_;
 };
@@ -49,8 +49,8 @@ class CmdObjectPool {
   // get the command object from the object pool
   std::pair<std::unique_ptr<BaseCmd>, CmdRes::CmdRet> GetCommand(const std::string &cmdName, PClient *client);
 
-  thread_local static std::unique_ptr<std::vector<SmallObject>> local_pool;
-  thread_local static uint64_t counter;
+  thread_local static std::unique_ptr<std::vector<SmallObject>> tl_local_pool;
+  thread_local static uint64_t tl_counter;
 
  private:
   // get the object from the global pool
@@ -77,6 +77,10 @@ class CmdObjectPool {
   const uint64_t local_max_ = 10;
   // How many operations have passed, check if you need to put the extra objects back into the global pool
   const uint64_t check_rate_ = 20;
+
+  // After multiple checks, if the number of times the object is used is still 1,
+  // it is also removed from the local_pool
+  const uint64_t less_use_check_rate_ = 3;
 };
 
 }  // namespace pikiwidb

--- a/src/cmd_object_pool.h
+++ b/src/cmd_object_pool.h
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) 2023-present, Qihoo, Inc.  All rights reserved.
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+#pragma once
+
+#include <algorithm>
+#include <iostream>
+#include <memory>
+
+#include "base_cmd.h"
+
+namespace pikiwidb {
+
+struct SmallObject {
+  // Version, after each use, a new version number is assigned
+  uint64_t version_;
+  std::string key_;
+  std::unique_ptr<BaseCmd> object_;
+};
+
+class CmdObjectPool {
+ public:
+  inline void SetNewObjectFunc(const std::string &key, std::function<std::unique_ptr<BaseCmd>()> &&func) {
+    create_object_.emplace(key, std::move(func));
+  }
+
+  inline void SetNewObjectFunc(
+      std::unordered_map<std::string, std::function<std::unique_ptr<BaseCmd>()>> &createObject) {
+    create_object_.insert(createObject.begin(), createObject.end());
+  }
+
+  void InitCommand();
+
+  // take all the objects and create them first
+  void InitObjectPool();
+
+  // Get the object from localPool first, if not found, get it from the global pool
+  std::unique_ptr<BaseCmd> GetObject(const std::string &key);
+
+  // recycle an object
+  void PutObject(std::string &&key, std::unique_ptr<BaseCmd> &&v);
+
+  // get the command object from the object pool
+  std::pair<std::unique_ptr<BaseCmd>, CmdRes::CmdRet> GetCommand(const std::string &cmdName, PClient *client);
+
+  thread_local static std::unique_ptr<std::vector<SmallObject>> local_pool;
+  thread_local static uint64_t counter;
+
+ private:
+  // get the object from the global pool
+  std::unique_ptr<BaseCmd> GetObjectByGlobal(const std::string &key);
+
+  // put the object back to the global pool
+  void PutObjectBackGlobal(const std::string &key, std::unique_ptr<BaseCmd> &v);
+
+  inline std::string ProcessSubcommandName(const std::string &cmdName) {
+    auto newName = cmdName;
+    std::transform(newName.begin(), newName.begin() + 1, newName.begin(), ::toupper);
+    return newName;
+  }
+
+ private:
+  // cache objects
+  std::unordered_map<std::string, std::unique_ptr<BaseCmd>> pool_;
+
+  // Based on the key, find the function that creates the object
+  std::unordered_map<std::string, std::function<std::unique_ptr<BaseCmd>()>> create_object_;
+  std::mutex mutex_;
+
+  // thread local pool size
+  const uint64_t local_max_ = 10;
+  // How many operations have passed, check if you need to put the extra objects back into the global pool
+  const uint64_t check_rate_ = 20;
+};
+
+}  // namespace pikiwidb

--- a/src/cmd_table_manager.cc
+++ b/src/cmd_table_manager.cc
@@ -33,10 +33,10 @@ void CmdTableManager::InitCmdTable() {
   std::unique_lock wl(mutex_);
 
   // admin
-  auto configPtr = std::make_unique<CmdConfig>(kCmdNameConfig, -2);
-  configPtr->AddSubCmd(std::make_unique<CmdConfigGet>("get", -3));
-  configPtr->AddSubCmd(std::make_unique<CmdConfigSet>("set", -4));
-  cmds_->insert(std::make_pair(kCmdNameConfig, std::move(configPtr)));
+  //  auto configPtr = std::make_unique<CmdConfig>(kCmdNameConfig, -2);
+  //  configPtr->AddSubCmd(std::make_unique<CmdConfigGet>("get", -3));
+  //  configPtr->AddSubCmd(std::make_unique<CmdConfigSet>("set", -4));
+  //  cmds_->insert(std::make_pair(kCmdNameConfig, std::move(configPtr)));
 
   // server
   ADD_COMMAND(Flushdb, 1);
@@ -158,12 +158,12 @@ std::pair<BaseCmd*, CmdRes::CmdRet> CmdTableManager::GetCommand(const std::strin
     return std::pair(nullptr, CmdRes::kSyntaxErr);
   }
 
-  if (cmd->second->HasSubCommand()) {
-    if (client->argv_.size() < 2) {
-      return std::pair(nullptr, CmdRes::kInvalidParameter);
-    }
-    return std::pair(cmd->second->GetSubCmd(client->argv_[1]), CmdRes::kSyntaxErr);
-  }
+  //  if (cmd->second->HasSubCommand()) {
+  //    if (client->argv_.size() < 2) {
+  //      return std::pair(nullptr, CmdRes::kInvalidParameter);
+  //    }
+  //    return std::pair(cmd->second->GetSubCmd(client->argv_[1]), CmdRes::kSyntaxErr);
+  //  }
   return std::pair(cmd->second.get(), CmdRes::kSyntaxErr);
 }
 

--- a/src/cmd_thread_pool_worker.cc
+++ b/src/cmd_thread_pool_worker.cc
@@ -24,7 +24,7 @@ void CmdWorkThreadPoolWorker::Work() {
         if (ret == CmdRes::kInvalidParameter) {
           task->Client()->SetRes(CmdRes::kInvalidParameter);
         } else {
-          task->Client()->SetRes(CmdRes::kSyntaxErr, "unknown command '" + task->CmdName() + "'");
+          task->Client()->SetRes(CmdRes::kErrOther, "unknown command '" + task->CmdName() + "'");
         }
         g_pikiwidb->PushWriteTask(task->Client());
         continue;

--- a/src/cmd_thread_pool_worker.cc
+++ b/src/cmd_thread_pool_worker.cc
@@ -11,7 +11,7 @@
 namespace pikiwidb {
 
 void CmdWorkThreadPoolWorker::Work() {
-  CmdObjectPool::local_pool = std::make_unique<std::vector<SmallObject>>();
+  CmdObjectPool::tl_local_pool = std::make_unique<std::vector<SmallObject>>();
   while (running_) {
     LoadWork();
     for (const auto &task : self_task_) {

--- a/src/cmd_thread_pool_worker.h
+++ b/src/cmd_thread_pool_worker.h
@@ -10,8 +10,12 @@
 #include <memory>
 #include <utility>
 
+#include "cmd_object_pool.h"
 #include "cmd_table_manager.h"
 #include "cmd_thread_pool.h"
+#include "pikiwidb.h"
+
+extern std::unique_ptr<PikiwiDB> g_pikiwidb;
 
 namespace pikiwidb {
 
@@ -19,7 +23,7 @@ class CmdWorkThreadPoolWorker {
  public:
   explicit CmdWorkThreadPoolWorker(CmdThreadPool *pool, int onceTask, std::string name)
       : pool_(pool), once_task_(onceTask), name_(std::move(name)) {
-    cmd_table_manager_.InitCmdTable();
+    cmd_object_pool_ = g_pikiwidb->GetCmdObjectPool();
   }
 
   void Work();
@@ -38,7 +42,7 @@ class CmdWorkThreadPoolWorker {
   const std::string name_;
   bool running_ = true;
 
-  pikiwidb::CmdTableManager cmd_table_manager_;
+  std::shared_ptr<CmdObjectPool> cmd_object_pool_;
 };
 
 // fast worker

--- a/src/pikiwidb.cc
+++ b/src/pikiwidb.cc
@@ -14,6 +14,7 @@
 #include <iostream>
 #include <thread>
 
+#include "cmd_object_pool.h"
 #include "log.h"
 #include "rocksdb/db.h"
 
@@ -29,6 +30,8 @@
 #include "pstd_util.h"
 
 std::unique_ptr<PikiwiDB> g_pikiwidb;
+
+// std::unique_ptr<pikiwidb::CmdObjectPool> g_cmd_object_pool;
 
 static void IntSigHandle(const int sig) {
   INFO("Catch Signal {}, cleanup...", sig);
@@ -248,6 +251,9 @@ bool PikiwiDB::Init() {
 
   //  cmd_table_manager_.InitCmdTable();
 
+  cmd_object_pool_ = std::make_shared<CmdObjectPool>();
+  cmd_object_pool_->InitCommand();
+
   return true;
 }
 
@@ -310,6 +316,7 @@ static void closeStd() {
 int main(int ac, char* av[]) {
   [[maybe_unused]] rocksdb::DB* db;
   g_pikiwidb = std::make_unique<PikiwiDB>();
+  //  g_cmd_object_pool = std::make_unique<pikiwidb::CmdObjectPool>();
 
   if (!g_pikiwidb->ParseArgs(ac - 1, av + 1)) {
     Usage();

--- a/src/pikiwidb.h
+++ b/src/pikiwidb.h
@@ -5,6 +5,7 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
+#include "cmd_object_pool.h"
 #include "cmd_table_manager.h"
 #include "cmd_thread_pool.h"
 #include "common.h"
@@ -42,6 +43,8 @@ class PikiwiDB final {
 
   void PushWriteTask(const std::shared_ptr<pikiwidb::PClient>& client) { worker_threads_.PushWriteTask(client); }
 
+  inline std::shared_ptr<pikiwidb::CmdObjectPool> GetCmdObjectPool() { return cmd_object_pool_; }
+
  public:
   PString cfg_file_;
   uint16_t port_{0};
@@ -58,6 +61,7 @@ class PikiwiDB final {
   pikiwidb::CmdThreadPool cmd_threads_;
   //  pikiwidb::CmdTableManager cmd_table_manager_;
 
+  std::shared_ptr<pikiwidb::CmdObjectPool> cmd_object_pool_;
   uint32_t cmd_id_ = 0;
 };
 


### PR DESCRIPTION
使用对象池来解决命令对象复用, 现在只是一个实现方案的思路验证,还请帮忙多检查

对象复用池在 `cmd_object_pool` 文件, 这个会代替 `cmd_table_manager` , 后续相关的文件会删除.

