### PR TITLE
fix: get log truncate index in storage

### DIFF
--- a/src/cmd_raft.cc
+++ b/src/cmd_raft.cc
@@ -122,7 +122,8 @@ void RaftNodeCmd::DoCmdRemove(PClient* client) {
 }
 
 void RaftNodeCmd::DoCmdSnapshot(PClient* client) {
-  auto s = PRAFT.DoSnapshot();
+  auto index = PSTORE.GetBackend(0)->GetStorage()->GetTruncateIndex();
+  auto s = PRAFT.TruncateLog(index);
   if (s.ok()) {
     client->SetRes(CmdRes::kOK);
   }

--- a/src/db.cc
+++ b/src/db.cc
@@ -11,6 +11,8 @@
 #include "praft/praft.h"
 #include "pstd/log.h"
 
+#include "storage/src/log_index.h"
+
 extern pikiwidb::PConfig g_config;
 
 namespace pikiwidb {
@@ -20,26 +22,28 @@ DB::DB(int db_index, const std::string& db_path)
 
 rocksdb::Status DB::Open() {
   storage::StorageOptions storage_options;
-  storage_options.options = g_config.GetRocksDBOptions();
-  storage_options.table_options = g_config.GetRocksDBBlockBasedTableOptions();
 
+  storage_options.options = g_config.GetRocksDBOptions();
+  storage_options.options.write_buffer_manager =
+      std::make_shared<rocksdb::WriteBufferManager>(storage_options.mem_manager_size);
   storage_options.options.ttl = g_config.rocksdb_ttl_second.load(std::memory_order_relaxed);
   storage_options.options.periodic_compaction_seconds =
       g_config.rocksdb_periodic_second.load(std::memory_order_relaxed);
 
+  storage_options.table_options = g_config.GetRocksDBBlockBasedTableOptions();
+
   storage_options.small_compaction_threshold = g_config.small_compaction_threshold.load();
   storage_options.small_compaction_duration_threshold = g_config.small_compaction_duration_threshold.load();
 
-  if (g_config.use_raft.load(std::memory_order_relaxed)) {
+  storage_options.db_instance_num = g_config.db_instance_num.load();
+  storage_options.db_id = db_index_;
+
+  storage_options.raft_mode = g_config.use_raft.load(std::memory_order_acquire);
+  if (storage_options.raft_mode) {
     storage_options.append_log_function = [&r = PRAFT](const Binlog& log, std::promise<rocksdb::Status>&& promise) {
       r.AppendLog(log, std::move(promise));
     };
-    storage_options.do_snapshot_function =
-        std::bind(&pikiwidb::PRaft::DoSnapshot, &pikiwidb::PRAFT, std::placeholders::_1, std::placeholders::_2);
   }
-
-  storage_options.db_instance_num = g_config.db_instance_num.load();
-  storage_options.db_id = db_index_;
 
   storage_ = std::make_unique<storage::Storage>();
 
@@ -103,8 +107,6 @@ void DB::LoadDBFromCheckpoint(const std::string& checkpoint_path, bool sync [[ma
     storage_options.append_log_function = [&r = PRAFT](const Binlog& log, std::promise<rocksdb::Status>&& promise) {
       r.AppendLog(log, std::move(promise));
     };
-    storage_options.do_snapshot_function =
-        std::bind(&pikiwidb::PRaft::DoSnapshot, &pikiwidb::PRAFT, std::placeholders::_1, std::placeholders::_2);
   }
   storage_ = std::make_unique<storage::Storage>();
 
@@ -116,4 +118,5 @@ void DB::LoadDBFromCheckpoint(const std::string& checkpoint_path, bool sync [[ma
   opened_ = true;
   INFO("DB{} load a checkpoint from {} success!", db_index_, checkpoint_path);
 }
+
 }  // namespace pikiwidb

--- a/src/io_thread_pool.cc
+++ b/src/io_thread_pool.cc
@@ -220,7 +220,6 @@ void WorkIOThreadPool::StartWorkers() {
 
 void WorkIOThreadPool::Exit() {
   IOThreadPool::Exit();
-
   writeRunning_ = false;
   int i = 0;
   for (auto& cond : writeCond_) {

--- a/src/pikiwidb.cc
+++ b/src/pikiwidb.cc
@@ -66,8 +66,8 @@ bool PikiwiDB::ParseArgs(int ac, char* av[]) {
       std::cerr << "PikiwiDB Server version: " << KPIKIWIDB_VERSION << " bits=" << (sizeof(void*) == 8 ? 64 : 32)
                 << std::endl;
       std::cerr << "PikiwiDB Server Build Type: " << KPIKIWIDB_BUILD_TYPE << std::endl;
-      std::cerr << "PikiwiDB Server Build Date: " << KPIKIWIDB_BUILD_DATE << std::endl;
-      std::cerr << "PikiwiDB Server Build GIT SHA: " << KPIKIWIDB_GIT_COMMIT_ID << std::endl;
+      //      std::cerr << "PikiwiDB Server Build Date: " << KPIKIWIDB_BUILD_DATE << std::endl;
+      //      std::cerr << "PikiwiDB Server Build GIT SHA: " << KPIKIWIDB_GIT_COMMIT_ID << std::endl;
 
       exit(0);
     } else if (strncasecmp(av[i], "-h", 2) == 0 || strncasecmp(av[i], "--help", 6) == 0) {
@@ -122,14 +122,14 @@ void PikiwiDB::OnNewConnection(pikiwidb::TcpConnection* obj) {
 bool PikiwiDB::Init() {
   char runid[kRunidSize + 1] = "";
   getRandomHexChars(runid, kRunidSize);
-  g_config.Set("runid", {runid, kRunidSize}, true);
+  g_config.Set("runid", {runid, kRunidSize}, true /* is_init_stage */);
 
   if (port_ != 0) {
-    g_config.Set("port", std::to_string(port_), true);
+    g_config.Set("port", std::to_string(port_), true /* is_init_stage */);
   }
 
   if (!log_level_.empty()) {
-    g_config.Set("log-level", log_level_, true);
+    g_config.Set("log-level", log_level_, true /* is_init_stage */);
   }
 
   NewTcpConnectionCallback cb = std::bind(&PikiwiDB::OnNewConnection, this, std::placeholders::_1);
@@ -176,7 +176,6 @@ bool PikiwiDB::Init() {
 void PikiwiDB::Run() {
   worker_threads_.SetName("pikiwi-main");
   slave_threads_.SetName("pikiwi-slave");
-
   cmd_threads_.Start();
 
   std::thread t([this]() {
@@ -194,12 +193,14 @@ void PikiwiDB::Run() {
 }
 
 void PikiwiDB::Stop() {
-  pikiwidb::PRAFT.ShutDown();
-  pikiwidb::PRAFT.Join();
-  pikiwidb::PRAFT.Clear();
   slave_threads_.Exit();
   worker_threads_.Exit();
   cmd_threads_.Stop();
+  if (g_config.use_raft.load(std::memory_order_relaxed)) {
+    pikiwidb::PRAFT.ShutDown();
+    pikiwidb::PRAFT.Join();
+    pikiwidb::PRAFT.Clear();
+  }
 }
 
 // pikiwidb::CmdTableManager& PikiwiDB::GetCmdTableManager() { return cmd_table_manager_; }
@@ -248,8 +249,9 @@ int main(int ac, char* av[]) {
 
   // output logo to console
   char logo[512] = "";
-  snprintf(logo, sizeof logo - 1, pikiwidbLogo, KPIKIWIDB_VERSION, static_cast<int>(sizeof(void*)) * 8,
-           static_cast<int>(g_config.port));
+  snprintf(
+      logo, sizeof logo - 1, pikiwidbLogo, KPIKIWIDB_VERSION, static_cast<int>(sizeof(void*)) * 8,
+      static_cast<int>((g_pikiwidb->port_ == 0) ? g_config.port.load(std::memory_order_relaxed) : g_pikiwidb->port_));
   std::cout << logo;
 
   if (g_config.daemonize.load()) {

--- a/src/praft/praft.cc
+++ b/src/praft/praft.cc
@@ -164,7 +164,21 @@ butil::Status PRaft::Init(std::string& group_id, bool initial_conf_is_null) {
     node_.reset();
     return ERROR_LOG_AND_STATUS("Failed to init raft node");
   }
+  auto res = std::async(
+      std::launch::async,
+      [this](std::chrono::minutes interval) {
+        while (true) {
+          std::this_thread::sleep_for(interval);
+          if (!this->server_->IsRunning()) {
+            return;
+          }
+          auto log_index = PSTORE.GetBackend(0)->GetStorage()->GetTruncateIndex();
+          TruncateLog(log_index);
+        }
+      },
+      std::chrono::minutes(30));
 
+  (void)res;
   return {0, "OK"};
 }
 
@@ -379,7 +393,6 @@ void PRaft::LeaderRedirection(PClient* join_client, const std::string& reply) {
   }
   PRAFT.GetClusterCmdCtx().ConnectTargetNode();
 
-  // Not reply any message here, we will reply after the connection is established.
   join_client->Clear();
 }
 
@@ -517,7 +530,7 @@ butil::Status PRaft::RemovePeer(const std::string& peer) {
   return {0, "OK"};
 }
 
-butil::Status PRaft::DoSnapshot(int64_t self_snapshot_index, bool is_sync) {
+butil::Status PRaft::TruncateLog(int64_t self_snapshot_index, bool is_sync) {
   if (!node_) {
     return ERROR_LOG_AND_STATUS("Node is not initialized");
   }

--- a/src/praft/praft.h
+++ b/src/praft/praft.h
@@ -104,7 +104,7 @@ class PRaft : public braft::StateMachine {
   butil::Status Init(std::string& group_id, bool initial_conf_is_null);
   butil::Status AddPeer(const std::string& peer);
   butil::Status RemovePeer(const std::string& peer);
-  butil::Status DoSnapshot(int64_t self_snapshot_index = 0, bool is_sync = true);
+  butil::Status TruncateLog(int64_t self_snapshot_index = 0, bool is_sync = true);
 
   void ShutDown();
   void Join();

--- a/src/storage/include/storage/storage.h
+++ b/src/storage/include/storage/storage.h
@@ -28,6 +28,7 @@
 #include "pstd/env.h"
 #include "pstd/pstd_mutex.h"
 #include "storage/slot_indexer.h"
+#include "storage/storage_define.h"
 
 namespace pikiwidb {
 class Binlog;
@@ -53,9 +54,11 @@ using BlockBasedTableOptions = rocksdb::BlockBasedTableOptions;
 using Status = rocksdb::Status;
 using Slice = rocksdb::Slice;
 using Env = rocksdb::Env;
+using SequenceNumber = rocksdb::SequenceNumber;
 using LogIndex = int64_t;
 
 class Redis;
+class PointPairOfRocksDB;
 enum class OptionType;
 
 template <typename T1, typename T2>
@@ -74,12 +77,12 @@ struct StorageOptions {
   size_t small_compaction_duration_threshold = 10000;
   size_t db_instance_num = 3;  // default = 3
   int db_id = 0;
-  AppendLogFunction append_log_function = nullptr;
-  DoSnapshotFunction do_snapshot_function = nullptr;
-
-  uint32_t raft_timeout_s = std::numeric_limits<uint32_t>::max();
-  int64_t max_gap = 1000;
   uint64_t mem_manager_size = 100000000;
+
+  bool raft_mode = false;
+  AppendLogFunction append_log_function = nullptr;
+  uint32_t raft_timeout_s = std::numeric_limits<uint32_t>::max();
+  int64_t max_gap = 40000;
   Status ResetOptions(const OptionType& option_type, const std::unordered_map<std::string, std::string>& options_map);
 };
 
@@ -179,6 +182,155 @@ struct BGTask {
       : type(_type), operation(_opeation), argv(_argv) {}
 };
 
+struct LogIndexSeqnoPair {
+  std::atomic<LogIndex> log_index = 0;
+  std::atomic<SequenceNumber> seqno = 0;
+
+  LogIndex GetLogIndex() const { return log_index.load(std::memory_order_relaxed); }
+
+  SequenceNumber GetSequenceNumber() const { return seqno.load(std::memory_order_relaxed); }
+
+  void SetLogIndexSeqnoPair(LogIndex l, SequenceNumber s) {
+    log_index.store(l, std::memory_order_relaxed);
+    seqno.store(s, std::memory_order_relaxed);
+  }
+
+  void SetMaxLogIndexSeqnoPair(LogIndex l, SequenceNumber s) {
+    log_index.store(std::max(log_index.load(), l));
+    seqno.store(std::max(seqno.load(), s));
+  }
+
+  LogIndexSeqnoPair() = default;
+
+  bool operator==(const LogIndexSeqnoPair& other) const {
+    return seqno.load(std::memory_order_relaxed) == other.seqno.load(std::memory_order_relaxed);
+  }
+
+  bool operator<=(const LogIndexSeqnoPair& other) const {
+    return seqno.load(std::memory_order_relaxed) <= other.seqno.load(std::memory_order_relaxed);
+  }
+
+  bool operator>=(const LogIndexSeqnoPair& other) const {
+    return seqno.load(std::memory_order_relaxed) >= other.seqno.load(std::memory_order_relaxed);
+  }
+
+  bool operator<(const LogIndexSeqnoPair& other) const {
+    return seqno.load(std::memory_order_relaxed) < other.seqno.load(std::memory_order_relaxed);
+  }
+};
+
+struct PointPair {
+  LogIndexSeqnoPair apply_point;  // The location of the latest entry written to the memtable in the braft log.
+  LogIndexSeqnoPair flush_point;  // The location of the latest persisted entry in the braft log.
+
+  bool IsEmpty() const { return flush_point >= apply_point; }
+};
+
+class PointPairOfRocksDB {
+  struct CurrentSmallestPoint {
+    int smallest_applied_log_index_cf = -1;
+    LogIndex smallest_applied_log_index = std::numeric_limits<LogIndex>::max();
+
+    int smallest_flushed_log_index_cf = -1;
+    LogIndex smallest_flushed_log_index = std::numeric_limits<LogIndex>::max();
+    SequenceNumber smallest_flushed_seqno = std::numeric_limits<SequenceNumber>::max();
+  };
+
+ public:
+  PointPairOfRocksDB() = default;
+
+  PointPairOfRocksDB(Redis* db) : db_(db) {}
+  // Read the largest log index of each column family from all sst files
+  rocksdb::Status Init();
+
+  // Find the smallest persisted data location and the smallest written
+  // data location among all column families, while skipping column families
+  // that have no unpersisted data.
+  CurrentSmallestPoint GetCurrentSmallestPoint(int current_flush_cf) const;
+
+  void SetFlushPoint(size_t cf_id, LogIndex log_index, SequenceNumber seqno) {
+    cf_[cf_id].flush_point.SetMaxLogIndexSeqnoPair(log_index, seqno);
+  }
+
+  void UpdataPersistedWatermark(LogIndex log_index, SequenceNumber seqno) {
+    // When the watermark is update, pull up the persistence data points of all Column Families that
+    // are below the watermark.
+    // This is to prevent the position of the persisted data from shrinking when a Column Family that
+    // hasn't been written to for a long time is written to again.
+    SetPersistedWatermark(log_index, seqno);
+    for (int i = 0; i < kColumnFamilyNum; i++) {
+      if (cf_[i].flush_point <= persisted_watermark_) {
+        auto flush_log_index = std::max(cf_[i].flush_point.GetLogIndex(), persisted_watermark_.GetLogIndex());
+        auto flush_sequence_number =
+            std::max(cf_[i].flush_point.GetSequenceNumber(), persisted_watermark_.GetSequenceNumber());
+        cf_[i].flush_point.SetLogIndexSeqnoPair(flush_log_index, flush_sequence_number);
+      }
+    }
+  }
+
+  bool IsApplied(size_t cf_id, LogIndex cur_log_index) const {
+    return cur_log_index < cf_[cf_id].apply_point.GetLogIndex();
+  }
+
+  void Update(size_t cf_id, LogIndex cur_log_index, SequenceNumber cur_seqno) {
+    if (cf_[cf_id].flush_point <= persisted_watermark_ && cf_[cf_id].flush_point == cf_[cf_id].apply_point) {
+      auto flush_log_index = std::max(cf_[cf_id].flush_point.GetLogIndex(), persisted_watermark_.GetLogIndex());
+      auto flush_sequence_number =
+          std::max(cf_[cf_id].flush_point.GetSequenceNumber(), persisted_watermark_.GetSequenceNumber());
+      cf_[cf_id].flush_point.SetLogIndexSeqnoPair(flush_log_index, flush_sequence_number);
+    }
+
+    cf_[cf_id].apply_point.SetLogIndexSeqnoPair(cur_log_index, cur_seqno);
+  }
+
+  void SetPersistedWatermark(LogIndex flushed_logindex, SequenceNumber flushed_seqno) {
+    auto persisted_watermark_log_index = std::max(persisted_watermark_.GetLogIndex(), flushed_logindex);
+    auto persisted_watermark_sequence_number = std::max(persisted_watermark_.GetSequenceNumber(), flushed_seqno);
+    persisted_watermark_.SetLogIndexSeqnoPair(persisted_watermark_log_index, persisted_watermark_sequence_number);
+  }
+
+  bool IsEmpty() const {
+    bool res = true;
+    for (auto& cf : cf_) {
+      if (!cf.IsEmpty()) {
+        res = false;
+        break;
+      }
+    }
+    return res;
+  }
+
+ public:
+  // for gtest
+  LogIndexSeqnoPair& GetPersistedWatermark() { return persisted_watermark_; }
+
+  PointPair& GetPointPair(size_t cf) { return cf_[cf]; }
+
+ private:
+  // Maintain two positions for each Column Family.One position indicates the maximum location of the data
+  // that has already been persisted for the Column Family, and the other position indicates the maximum
+  // location of the data that has been written to the Column Family.
+  //
+  // for example:
+  // logindex  1           3                           8
+  //                                                   |
+  //                                        cf0_applied/flushed_point
+  // logindex         2           4               7          9    ...   15
+  //                  |                                                 |
+  //            cf1_flush_point                                  cf1_applied_point
+  // logindex        /\                 5     6           ...                16
+  //                 |                        |                              |
+  //                 |                  cf2_flush_point                cf2_applied_point
+  //                 |
+  //          persisted_watermark
+  std::array<PointPair, kColumnFamilyNum> cf_;
+  // Maintain a watermark for each RocksDB instance, ensuring that all data below this line has been persisted.
+  // when Column Family's flush operation completes, this value is calculated and updated.
+  //
+  LogIndexSeqnoPair persisted_watermark_;
+  Redis* db_;
+};
+
 class Storage {
  public:
   Storage();
@@ -193,6 +345,10 @@ class Storage {
   std::vector<std::future<Status>> LoadCheckpoint(const std::string& checkpoint_path, const std::string& db_path);
 
   Status LoadCheckpointInternal(const std::string& dump_path, const std::string& db_path, int index);
+
+  std::vector<std::future<Status>> FlushAll();
+
+  Status FlushAllInternal(int index);
 
   Status LoadCursorStartKey(const DataType& dtype, int64_t cursor, char* type, std::string* start_key);
 
@@ -1108,10 +1264,15 @@ class Storage {
 
   Status SetOptions(const OptionType& option_type, const std::unordered_map<std::string, std::string>& options);
   void GetRocksDBInfo(std::string& info);
+
+  // raft
   Status OnBinlogWrite(const pikiwidb::Binlog& log, LogIndex log_idx);
+
+  LogIndex GetTruncateIndex();
 
  private:
   std::vector<std::unique_ptr<Redis>> insts_;
+  std::vector<std::unique_ptr<PointPairOfRocksDB>> points_;
   std::unique_ptr<SlotIndexer> slot_indexer_;
   std::atomic<bool> is_opened_ = false;
 
@@ -1130,6 +1291,10 @@ class Storage {
   std::atomic<bool> scan_keynum_exit_ = false;
   size_t db_instance_num_ = 3;
   int db_id_ = 0;
+
+  // For raft
+  bool raft_mode_ = false;
+  std::atomic<LogIndex> last_truncate_point_ = 0;
 };
 
 }  //  namespace storage

--- a/src/storage/src/log_index.cc
+++ b/src/storage/src/log_index.cc
@@ -12,65 +12,11 @@
 #include <set>
 
 #include "redis.h"
+#include "storage/storage.h"
 
 namespace storage {
 
-rocksdb::Status storage::LogIndexOfColumnFamilies::Init(Redis *db) {
-  for (int i = 0; i < cf_.size(); i++) {
-    rocksdb::TablePropertiesCollection collection;
-    auto s = db->GetDB()->GetPropertiesOfAllTables(db->GetColumnFamilyHandles()[i], &collection);
-    if (!s.ok()) {
-      return s;
-    }
-    auto res = LogIndexTablePropertiesCollector::GetLargestLogIndexFromTableCollection(collection);
-    if (res.has_value()) {
-      auto log_index = res->GetAppliedLogIndex();
-      auto sequence_number = res->GetSequenceNumber();
-      cf_[i].applied_index.SetLogIndexSeqnoPair(log_index, sequence_number);
-      cf_[i].flushed_index.SetLogIndexSeqnoPair(log_index, sequence_number);
-    }
-  }
-  return Status::OK();
-}
-
-LogIndexOfColumnFamilies::SmallestIndexRes LogIndexOfColumnFamilies::GetSmallestLogIndex(int flush_cf) const {
-  SmallestIndexRes res;
-  for (int i = 0; i < cf_.size(); i++) {
-    if (i != flush_cf && cf_[i].flushed_index >= cf_[i].applied_index) {
-      continue;
-    }
-    auto applied_log_index = cf_[i].applied_index.GetLogIndex();
-    auto flushed_log_index = cf_[i].flushed_index.GetLogIndex();
-    auto flushed_seqno = cf_[i].flushed_index.GetSequenceNumber();
-    if (applied_log_index < res.smallest_applied_log_index) {
-      res.smallest_applied_log_index = applied_log_index;
-      res.smallest_applied_log_index_cf = i;
-    }
-    if (flushed_log_index < res.smallest_flushed_log_index) {
-      res.smallest_flushed_log_index = flushed_log_index;
-      res.smallest_flushed_seqno = flushed_seqno;
-      res.smallest_flushed_log_index_cf = i;
-    }
-  }
-  return res;
-}
-
-size_t LogIndexOfColumnFamilies::GetPendingFlushGap() const {
-  std::set<int> s;
-  for (int i = 0; i < kColumnFamilyNum; i++) {
-    s.insert(cf_[i].applied_index.GetLogIndex());
-    s.insert(cf_[i].flushed_index.GetLogIndex());
-  }
-  assert(!s.empty());
-  if (s.size() == 1) {
-    return false;
-  }
-  auto iter_first = s.begin();
-  auto iter_last = s.end();
-  return *std::prev(iter_last) - *iter_first;
-};
-
-std::atomic_int64_t LogIndexAndSequenceCollector::max_gap_ = 1000;
+std::atomic_int64_t LogIndexAndSequenceCollector::max_gap = 40000;
 
 std::optional<LogIndexAndSequencePair> storage::LogIndexTablePropertiesCollector::ReadStatsFromTableProps(
     const std::shared_ptr<const rocksdb::TableProperties> &table_props) {
@@ -154,20 +100,16 @@ auto LogIndexTablePropertiesCollector::GetLargestLogIndexFromTableCollection(
 
 void LogIndexAndSequenceCollectorPurger::OnFlushCompleted(rocksdb::DB *db,
                                                           const rocksdb::FlushJobInfo &flush_job_info) {
-  cf_->SetFlushedLogIndex(flush_job_info.cf_id, collector_->FindAppliedLogIndex(flush_job_info.largest_seqno),
-                          flush_job_info.largest_seqno);
+  cf_->SetFlushPoint(flush_job_info.cf_id, collector_->FindAppliedLogIndex(flush_job_info.largest_seqno),
+                     flush_job_info.largest_seqno);
 
   auto [smallest_applied_log_index_cf, smallest_applied_log_index, smallest_flushed_log_index_cf,
-        smallest_flushed_log_index, smallest_flushed_seqno] = cf_->GetSmallestLogIndex(flush_job_info.cf_id);
+        smallest_flushed_log_index, smallest_flushed_seqno] = cf_->GetCurrentSmallestPoint(flush_job_info.cf_id);
   collector_->Purge(smallest_applied_log_index);
 
   if (smallest_flushed_log_index_cf != -1) {
-    cf_->SetFlushedLogIndexGlobal(smallest_flushed_log_index, smallest_flushed_seqno);
-  }
-  auto count = count_.fetch_add(1);
-
-  if (count % 10 == 0) {
-    callback_(smallest_flushed_log_index, false);
+    assert(cf_);
+    cf_->UpdataPersistedWatermark(smallest_flushed_log_index, smallest_flushed_seqno);
   }
 
   if (flush_job_info.cf_id == manul_flushing_cf_.load()) {
@@ -188,6 +130,7 @@ void LogIndexAndSequenceCollectorPurger::OnFlushCompleted(rocksdb::DB *db,
   assert(manul_flushing_cf_.load() == smallest_flushed_log_index_cf);
   rocksdb::FlushOptions flush_option;
   flush_option.wait = false;
+  std::printf("1");
   db->Flush(flush_option, column_families_->at(smallest_flushed_log_index_cf));
 }
 

--- a/src/storage/src/log_index.h
+++ b/src/storage/src/log_index.h
@@ -22,7 +22,7 @@
 #include "rocksdb/table_properties.h"
 #include "rocksdb/types.h"
 
-#include "storage/storage_define.h"
+#include "storage/storage.h"
 
 namespace storage {
 
@@ -46,103 +46,6 @@ class LogIndexAndSequencePair {
   SequenceNumber seqno_ = 0;
 };
 
-struct LogIndexSeqnoPair {
-  std::atomic<LogIndex> log_index = 0;
-  std::atomic<SequenceNumber> seqno = 0;
-
-  LogIndex GetLogIndex() const { return log_index.load(); }
-
-  SequenceNumber GetSequenceNumber() const { return seqno.load(); }
-
-  void SetLogIndexSeqnoPair(LogIndex l, SequenceNumber s) {
-    log_index.store(l);
-    seqno.store(s);
-  }
-
-  LogIndexSeqnoPair() = default;
-
-  bool operator==(const LogIndexSeqnoPair &other) const { return seqno.load() == other.seqno.load(); }
-
-  bool operator<=(const LogIndexSeqnoPair &other) const { return seqno.load() <= other.seqno.load(); }
-
-  bool operator>=(const LogIndexSeqnoPair &other) const { return seqno.load() >= other.seqno.load(); }
-
-  bool operator<(const LogIndexSeqnoPair &other) const { return seqno.load() < other.seqno.load(); }
-};
-
-class LogIndexOfColumnFamilies {
-  struct LogIndexPair {
-    LogIndexSeqnoPair applied_index;  // newest record in memtable.
-    LogIndexSeqnoPair flushed_index;  // newest record in sst file.
-  };
-
-  struct SmallestIndexRes {
-    int smallest_applied_log_index_cf = -1;
-    LogIndex smallest_applied_log_index = std::numeric_limits<LogIndex>::max();
-
-    int smallest_flushed_log_index_cf = -1;
-    LogIndex smallest_flushed_log_index = std::numeric_limits<LogIndex>::max();
-    SequenceNumber smallest_flushed_seqno = std::numeric_limits<SequenceNumber>::max();
-  };
-
- public:
-  // Read the largest log index of each column family from all sst files
-  rocksdb::Status Init(Redis *db);
-
-  SmallestIndexRes GetSmallestLogIndex(int flush_cf) const;
-
-  void SetFlushedLogIndex(size_t cf_id, LogIndex log_index, SequenceNumber seqno) {
-    cf_[cf_id].flushed_index.log_index.store(std::max(cf_[cf_id].flushed_index.log_index.load(), log_index));
-    cf_[cf_id].flushed_index.seqno.store(std::max(cf_[cf_id].flushed_index.seqno.load(), seqno));
-  }
-
-  void SetFlushedLogIndexGlobal(LogIndex log_index, SequenceNumber seqno) {
-    SetLastFlushIndex(log_index, seqno);
-    for (int i = 0; i < kColumnFamilyNum; i++) {
-      if (cf_[i].flushed_index <= last_flush_index_) {
-        auto flush_log_index = std::max(cf_[i].flushed_index.GetLogIndex(), last_flush_index_.GetLogIndex());
-        auto flush_sequence_number =
-            std::max(cf_[i].flushed_index.GetSequenceNumber(), last_flush_index_.GetSequenceNumber());
-        cf_[i].flushed_index.SetLogIndexSeqnoPair(flush_log_index, flush_sequence_number);
-      }
-    }
-  }
-
-  bool IsApplied(size_t cf_id, LogIndex cur_log_index) const {
-    return cur_log_index < cf_[cf_id].applied_index.GetLogIndex();
-  }
-
-  void Update(size_t cf_id, LogIndex cur_log_index, SequenceNumber cur_seqno) {
-    if (cf_[cf_id].flushed_index <= last_flush_index_ && cf_[cf_id].flushed_index == cf_[cf_id].applied_index) {
-      auto flush_log_index = std::max(cf_[cf_id].flushed_index.GetLogIndex(), last_flush_index_.GetLogIndex());
-      auto flush_sequence_number =
-          std::max(cf_[cf_id].flushed_index.GetSequenceNumber(), last_flush_index_.GetSequenceNumber());
-      cf_[cf_id].flushed_index.SetLogIndexSeqnoPair(flush_log_index, flush_sequence_number);
-    }
-
-    cf_[cf_id].applied_index.SetLogIndexSeqnoPair(cur_log_index, cur_seqno);
-  }
-
-  bool IsPendingFlush() const;
-
-  size_t GetPendingFlushGap() const;
-
-  void SetLastFlushIndex(LogIndex flushed_logindex, SequenceNumber flushed_seqno) {
-    auto lastest_flush_log_index = std::max(last_flush_index_.GetLogIndex(), flushed_logindex);
-    auto lastest_flush_sequence_number = std::max(last_flush_index_.GetSequenceNumber(), flushed_seqno);
-    last_flush_index_.SetLogIndexSeqnoPair(lastest_flush_log_index, lastest_flush_sequence_number);
-  }
-
-  // for gtest
-  LogIndexSeqnoPair &GetLastFlushIndex() { return last_flush_index_; }
-
-  LogIndexPair &GetCFStatus(size_t cf) { return cf_[cf]; }
-
- private:
-  std::array<LogIndexPair, kColumnFamilyNum> cf_;
-  LogIndexSeqnoPair last_flush_index_;
-};
-
 class LogIndexAndSequenceCollector {
  public:
   explicit LogIndexAndSequenceCollector(uint8_t step_length_bit = 0) { step_length_mask_ = (1 << step_length_bit) - 1; }
@@ -157,7 +60,7 @@ class LogIndexAndSequenceCollector {
   void Purge(LogIndex smallest_applied_log_index);
 
   // Is manual flushing required?
-  bool IsFlushPending() const { return GetSize() >= max_gap_; }
+  bool IsFlushPending() const { return GetSize() >= max_gap.load(); }
 
   // for gtest
   uint64_t GetSize() const {
@@ -171,7 +74,7 @@ class LogIndexAndSequenceCollector {
   }
 
  public:
-  static std::atomic_int64_t max_gap_;
+  static std::atomic_int64_t max_gap;
 
  private:
   uint64_t step_length_mask_ = 0;
@@ -238,19 +141,16 @@ class LogIndexTablePropertiesCollectorFactory : public rocksdb::TablePropertiesC
 class LogIndexAndSequenceCollectorPurger : public rocksdb::EventListener {
  public:
   explicit LogIndexAndSequenceCollectorPurger(std::vector<rocksdb::ColumnFamilyHandle *> *column_families,
-                                              LogIndexAndSequenceCollector *collector, LogIndexOfColumnFamilies *cf,
-                                              std::function<void(int64_t, bool)> callback)
-      : column_families_(column_families), collector_(collector), cf_(cf), callback_(callback) {}
+                                              LogIndexAndSequenceCollector *collector, PointPairOfRocksDB *cf)
+      : column_families_(column_families), collector_(collector), cf_(cf) {}
 
   void OnFlushCompleted(rocksdb::DB *db, const rocksdb::FlushJobInfo &flush_job_info) override;
 
  private:
   std::vector<rocksdb::ColumnFamilyHandle *> *column_families_ = nullptr;
   LogIndexAndSequenceCollector *collector_ = nullptr;
-  LogIndexOfColumnFamilies *cf_ = nullptr;
-  std::atomic_uint64_t count_ = 0;
+  PointPairOfRocksDB *cf_ = nullptr;
   std::atomic<size_t> manul_flushing_cf_ = -1;
-  std::function<void(int64_t, bool)> callback_;
 };
 
 }  // namespace storage

--- a/src/storage/src/redis.cc
+++ b/src/storage/src/redis.cc
@@ -60,6 +60,7 @@ Redis::~Redis() {
 }
 
 Status Redis::Open(const StorageOptions& storage_options, const std::string& db_path) {
+  is_raft_mode_ = storage_options.raft_mode;
   append_log_function_ = storage_options.append_log_function;
   raft_timeout_s_ = storage_options.raft_timeout_s;
   statistics_store_->SetCapacity(storage_options.statistics_max_size);
@@ -146,7 +147,8 @@ Status Redis::Open(const StorageOptions& storage_options, const std::string& db_
   zset_data_cf_ops.table_factory.reset(rocksdb::NewBlockBasedTableFactory(zset_data_cf_table_ops));
   zset_score_cf_ops.table_factory.reset(rocksdb::NewBlockBasedTableFactory(zset_score_cf_table_ops));
 
-  if (append_log_function_) {
+  if (is_raft_mode_) {
+    assert(append_log_function_);
     // Add log index table property collector factory to each column family
     ADD_TABLE_PROPERTY_COLLECTOR_FACTORY(string);
     ADD_TABLE_PROPERTY_COLLECTOR_FACTORY(hash_meta);
@@ -160,8 +162,9 @@ Status Redis::Open(const StorageOptions& storage_options, const std::string& db_
     ADD_TABLE_PROPERTY_COLLECTOR_FACTORY(zset_score);
 
     // Add a listener on flush to purge log index collector
-    db_ops.listeners.push_back(std::make_shared<LogIndexAndSequenceCollectorPurger>(
-        &handles_, &log_index_collector_, &log_index_of_all_cfs_, storage_options.do_snapshot_function));
+    assert(point_pair_of_all_cfs_);
+    db_ops.listeners.push_back(
+        std::make_shared<LogIndexAndSequenceCollectorPurger>(&handles_, &log_index_collector_, point_pair_of_all_cfs_));
   }
 
   std::vector<rocksdb::ColumnFamilyDescriptor> column_families;
@@ -185,7 +188,11 @@ Status Redis::Open(const StorageOptions& storage_options, const std::string& db_
     return s;
   }
   assert(!handles_.empty());
-  return log_index_of_all_cfs_.Init(this);
+  assert(!is_raft_mode_ || point_pair_of_all_cfs_);
+  if (!is_raft_mode_) {
+    return s;
+  }
+  return point_pair_of_all_cfs_->Init();
 }
 
 Status Redis::GetScanStartPoint(const DataType& type, const Slice& key, const Slice& pattern, int64_t cursor,

--- a/src/storage/src/redis.h
+++ b/src/storage/src/redis.h
@@ -104,9 +104,9 @@ class Redis {
                               const ColumnFamilyType& type = kMetaAndData);
 
   virtual Status GetProperty(const std::string& property, uint64_t* out);
-  bool IsApplied(size_t cf_idx, LogIndex logidx) const { return log_index_of_all_cfs_.IsApplied(cf_idx, logidx); }
+  bool IsApplied(size_t cf_idx, LogIndex logidx) const { return point_pair_of_all_cfs_->IsApplied(cf_idx, logidx); }
   void UpdateAppliedLogIndexOfColumnFamily(size_t cf_idx, LogIndex logidx, SequenceNumber seqno) {
-    log_index_of_all_cfs_.Update(cf_idx, logidx, seqno);
+    point_pair_of_all_cfs_->Update(cf_idx, logidx, seqno);
   }
   bool IsRestarting() const { return is_starting_; }
   void StartingPhaseEnd() { is_starting_ = false; }
@@ -306,10 +306,6 @@ class Redis {
   void ScanZsets();
   void ScanSets();
 
-  void UpdateLogIndex(LogIndex applied_log_index, SequenceNumber seqno) {
-    log_index_collector_.Update(applied_log_index, seqno);
-  }
-
   TypeIterator* CreateIterator(const DataType& type, const std::string& pattern, const Slice* lower_bound,
                                const Slice* upper_bound) {
     return CreateIterator(DataTypeTag[type], pattern, lower_bound, upper_bound);
@@ -344,7 +340,20 @@ class Redis {
     return nullptr;
   }
 
-  LogIndexOfColumnFamilies& GetLogIndexOfColumnFamilies() { return log_index_of_all_cfs_; }
+ public:
+  // raft
+  void UpdateLogIndex(LogIndex applied_log_index, SequenceNumber seqno) {
+    log_index_collector_.Update(applied_log_index, seqno);
+  }
+
+  void SetPointPairOfRocksDB(PointPairOfRocksDB* p) {
+    assert(p);
+    point_pair_of_all_cfs_ = p;
+  }
+
+ public:
+  // for gtest
+  PointPairOfRocksDB* GetPointPairOfColumnFamilies() { return point_pair_of_all_cfs_; }
 
   LogIndexAndSequenceCollector& GetCollector() { return log_index_collector_; }
 
@@ -374,10 +383,11 @@ class Redis {
   std::unique_ptr<LRUCache<std::string, KeyStatistics>> statistics_store_;
 
   // For raft
+  bool is_raft_mode_ = false;
   uint32_t raft_timeout_s_ = 10;
   AppendLogFunction append_log_function_;
   LogIndexAndSequenceCollector log_index_collector_;
-  LogIndexOfColumnFamilies log_index_of_all_cfs_;
+  PointPairOfRocksDB* point_pair_of_all_cfs_ = nullptr;
   bool is_starting_{true};
 
   Status UpdateSpecificKeyStatistics(const DataType& dtype, const std::string& key, uint64_t count);

--- a/src/storage/src/storage.cc
+++ b/src/storage/src/storage.cc
@@ -6,6 +6,7 @@
 #include <algorithm>
 #include <filesystem>
 #include <future>
+#include <iterator>
 #include <string_view>
 #include <utility>
 #include <vector>
@@ -33,6 +34,48 @@
 namespace storage {
 extern std::string BitOpOperate(BitOpType op, const std::vector<std::string>& src_values, int64_t max_len);
 class Redis;
+
+rocksdb::Status storage::PointPairOfRocksDB::Init() {
+  assert(db_);
+  for (int i = 0; i < cf_.size(); i++) {
+    rocksdb::TablePropertiesCollection collection;
+    auto s = db_->GetDB()->GetPropertiesOfAllTables(db_->GetColumnFamilyHandles()[i], &collection);
+    if (!s.ok()) {
+      return s;
+    }
+    auto res = LogIndexTablePropertiesCollector::GetLargestLogIndexFromTableCollection(collection);
+    if (res.has_value()) {
+      auto log_index = res->GetAppliedLogIndex();
+      auto sequence_number = res->GetSequenceNumber();
+      cf_[i].apply_point.SetLogIndexSeqnoPair(log_index, sequence_number);
+      cf_[i].flush_point.SetLogIndexSeqnoPair(log_index, sequence_number);
+      persisted_watermark_.SetMaxLogIndexSeqnoPair(log_index, sequence_number);
+    }
+  }
+  return Status::OK();
+}
+
+PointPairOfRocksDB::CurrentSmallestPoint PointPairOfRocksDB::GetCurrentSmallestPoint(int current_flush_cf) const {
+  CurrentSmallestPoint res;
+  for (int i = 0; i < cf_.size(); i++) {
+    if (i != current_flush_cf && cf_[i].IsEmpty()) {
+      continue;
+    }
+    auto applied_log_index = cf_[i].apply_point.GetLogIndex();
+    auto flushed_log_index = cf_[i].flush_point.GetLogIndex();
+    auto flushed_seqno = cf_[i].flush_point.GetSequenceNumber();
+    if (applied_log_index < res.smallest_applied_log_index) {
+      res.smallest_applied_log_index = applied_log_index;
+      res.smallest_applied_log_index_cf = i;
+    }
+    if (flushed_log_index < res.smallest_flushed_log_index) {
+      res.smallest_flushed_log_index = flushed_log_index;
+      res.smallest_flushed_seqno = flushed_seqno;
+      res.smallest_flushed_log_index_cf = i;
+    }
+  }
+  return res;
+}
 
 Status StorageOptions::ResetOptions(const OptionType& option_type,
                                     const std::unordered_map<std::string, std::string>& options_map) {
@@ -129,13 +172,24 @@ static int RecursiveLinkAndCopy(const std::filesystem::path& source, const std::
 Status Storage::Open(const StorageOptions& storage_options, const std::string& db_path) {
   mkpath(db_path.c_str(), 0755);
   db_instance_num_ = storage_options.db_instance_num;
-  // Temporarily set to 100000
-  LogIndexAndSequenceCollector::max_gap_.store(storage_options.max_gap);
-  storage_options.options.write_buffer_manager =
-      std::make_shared<rocksdb::WriteBufferManager>(storage_options.mem_manager_size);
-  for (size_t index = 0; index < db_instance_num_; index++) {
+  raft_mode_ = storage_options.raft_mode;
+  insts_.clear();
+  for (size_t index = 0; index < db_instance_num_; ++index) {
     insts_.emplace_back(std::make_unique<Redis>(this, index));
-    Status s = insts_.back()->Open(storage_options, AppendSubDirectory(db_path, index));
+  }
+  if (raft_mode_) {
+    std::printf("raft mode\n");
+    points_.clear();
+    for (size_t index = 0; index < db_instance_num_; ++index) {
+      points_.emplace_back(std::make_unique<PointPairOfRocksDB>(insts_[index].get()));
+      insts_[index]->SetPointPairOfRocksDB(points_.back().get());
+    }
+    LogIndexAndSequenceCollector::max_gap = storage_options.max_gap;
+    assert(points_.size() == insts_.size());
+  }
+
+  for (size_t index = 0; index < db_instance_num_; ++index) {
+    Status s = insts_[index]->Open(storage_options, AppendSubDirectory(db_path, index));
     if (!s.ok()) {
       ERROR("open RocksDB{} failed {}", index, s.ToString());
       return Status::IOError();
@@ -261,6 +315,25 @@ Status Storage::LoadCheckpointInternal(const std::string& checkpoint_sub_path, c
     WARN("Failure to destroy the old DB, path = {}", tmp_rocksdb_path);
   }
   return Status::OK();
+}
+
+std::vector<std::future<Status>> Storage::FlushAll() {
+  INFO("DB{} begin to flush and truncate log", db_id_);
+  std::vector<std::future<Status>> result;
+  result.reserve(db_instance_num_);
+  for (int i = 0; i < db_instance_num_; ++i) {
+    // In a new thread, Load a checkpoint for the specified rocksdb i
+    auto res = std::async(std::launch::async, &Storage::FlushAllInternal, this, i);
+    result.push_back(std::move(res));
+  }
+  return result;
+}
+
+Status Storage::FlushAllInternal(int index) {
+  auto& db_wrapper = insts_[index];
+  auto s = db_wrapper->GetDB()->Flush(rocksdb::FlushOptions(), db_wrapper->GetColumnFamilyHandles());
+  // wait until flush finish.
+  return s;
 }
 
 Status Storage::LoadCursorStartKey(const DataType& dtype, int64_t cursor, char* type, std::string* start_key) {
@@ -2406,6 +2479,22 @@ Status Storage::OnBinlogWrite(const pikiwidb::Binlog& log, LogIndex log_idx) {
   }
   inst->UpdateLogIndex(log_idx, first_seqno);
   return s;
+}
+
+LogIndex Storage::GetTruncateIndex() {
+  for (auto& p : points_) {
+    if (p->IsEmpty()) {
+      continue;
+    }
+
+    auto logindex = p->GetPersistedWatermark().GetLogIndex();
+    if (last_truncate_point_ == 0) {
+      last_truncate_point_.store(logindex);
+    } else {
+      last_truncate_point_ = std::min(last_truncate_point_.load(), logindex);
+    }
+  }
+  return last_truncate_point_;
 }
 
 }  //  namespace storage

--- a/src/storage/tests/flush_oldest_cf_test.cc
+++ b/src/storage/tests/flush_oldest_cf_test.cc
@@ -66,13 +66,14 @@ class FlushOldestCFTest : public ::testing::Test {
   FlushOldestCFTest()
       : log_queue_([this](const pikiwidb::Binlog& log, LogIndex log_idx) { return db_.OnBinlogWrite(log, log_idx); }) {
     options_.options.create_if_missing = true;
-    options_.options.max_background_jobs = 10;
+    options_.options.create_missing_column_families = true;
+    options_.options.max_background_jobs = 20;
     options_.db_instance_num = 1;
+    options_.raft_mode = true;
     options_.raft_timeout_s = 9000000;
     options_.append_log_function = [this](const pikiwidb::Binlog& log, std::promise<rocksdb::Status>&& promise) {
       log_queue_.AppendLog(log, std::move(promise));
     };
-    options_.do_snapshot_function = [](int64_t log_index, bool sync) {};
     options_.max_gap = 15;
     write_options_.disableWAL = true;
   }
@@ -103,6 +104,8 @@ class FlushOldestCFTest : public ::testing::Test {
 
 TEST_F(FlushOldestCFTest, SimpleTest) {
   const auto& rocksdb = db_.GetDBInstance(key_);
+  auto max_gap = rocksdb->GetCollector().max_gap.load();
+  ASSERT_EQ(max_gap, 15);
 
   auto add_kvs = [&](int start, int end) {
     for (int i = start; i < end; i++) {
@@ -141,19 +144,19 @@ TEST_F(FlushOldestCFTest, SimpleTest) {
     // last_flush_index   log_index    sequencenumber
     //                        0              0
     add_kvs(0, 10);
-    auto& last_flush_index = rocksdb->GetLogIndexOfColumnFamilies().GetLastFlushIndex();
+    auto& last_flush_index = rocksdb->GetPointPairOfColumnFamilies()->GetPersistedWatermark();
     ASSERT_EQ(last_flush_index.log_index.load(), 0);
     ASSERT_EQ(last_flush_index.seqno.load(), 0);
 
-    auto& cf_0_status = rocksdb->GetLogIndexOfColumnFamilies().GetCFStatus(storage::kStringsCF);
-    ASSERT_EQ(cf_0_status.flushed_index.log_index, 0);
-    ASSERT_EQ(cf_0_status.flushed_index.seqno, 0);
-    ASSERT_EQ(cf_0_status.applied_index.log_index, 10);
-    ASSERT_EQ(cf_0_status.applied_index.seqno, 10);
+    auto& cf_0_status = rocksdb->GetPointPairOfColumnFamilies()->GetPointPair(storage::kStringsCF);
+    ASSERT_EQ(cf_0_status.flush_point.GetLogIndex(), 0);
+    ASSERT_EQ(cf_0_status.flush_point.GetSequenceNumber(), 0);
+    ASSERT_EQ(cf_0_status.apply_point.GetLogIndex(), 10);
+    ASSERT_EQ(cf_0_status.apply_point.GetSequenceNumber(), 10);
 
     auto [smallest_applied_log_index_cf, smallest_applied_log_index, smallest_flushed_log_index_cf,
           smallest_flushed_log_index, smallest_flushed_seqno] =
-        rocksdb->GetLogIndexOfColumnFamilies().GetSmallestLogIndex(-1);
+        rocksdb->GetPointPairOfColumnFamilies()->GetCurrentSmallestPoint(-1);
 
     ASSERT_EQ(smallest_flushed_log_index, 0);
     ASSERT_EQ(smallest_flushed_seqno, 0);
@@ -175,25 +178,25 @@ TEST_F(FlushOldestCFTest, SimpleTest) {
     // last_flush_index   log_index    sequencenumber
     //                       0               0
     add_hash(10, 30);
-    auto& last_flush_index = rocksdb->GetLogIndexOfColumnFamilies().GetLastFlushIndex();
-    ASSERT_EQ(last_flush_index.log_index.load(), 0);
-    ASSERT_EQ(last_flush_index.seqno.load(), 0);
+    auto& last_flush_index = rocksdb->GetPointPairOfColumnFamilies()->GetPersistedWatermark();
+    ASSERT_EQ(last_flush_index.GetLogIndex(), 0);
+    ASSERT_EQ(last_flush_index.GetSequenceNumber(), 0);
 
-    auto& cf_1_status = rocksdb->GetLogIndexOfColumnFamilies().GetCFStatus(storage::kHashesMetaCF);
-    ASSERT_EQ(cf_1_status.flushed_index.log_index, 0);
-    ASSERT_EQ(cf_1_status.flushed_index.seqno, 0);
-    ASSERT_EQ(cf_1_status.applied_index.log_index, 30);
-    ASSERT_EQ(cf_1_status.applied_index.seqno, 49);
+    auto& cf_1_status = rocksdb->GetPointPairOfColumnFamilies()->GetPointPair(storage::kHashesMetaCF);
+    ASSERT_EQ(cf_1_status.flush_point.GetLogIndex(), 0);
+    ASSERT_EQ(cf_1_status.flush_point.GetSequenceNumber(), 0);
+    ASSERT_EQ(cf_1_status.apply_point.GetLogIndex(), 30);
+    ASSERT_EQ(cf_1_status.apply_point.GetSequenceNumber(), 49);
 
-    auto& cf_2_status = rocksdb->GetLogIndexOfColumnFamilies().GetCFStatus(storage::kHashesDataCF);
-    ASSERT_EQ(cf_2_status.flushed_index.log_index, 0);
-    ASSERT_EQ(cf_2_status.flushed_index.seqno, 0);
-    ASSERT_EQ(cf_2_status.applied_index.log_index, 30);
-    ASSERT_EQ(cf_2_status.applied_index.seqno, 50);
+    auto& cf_2_status = rocksdb->GetPointPairOfColumnFamilies()->GetPointPair(storage::kHashesDataCF);
+    ASSERT_EQ(cf_2_status.flush_point.GetLogIndex(), 0);
+    ASSERT_EQ(cf_2_status.flush_point.GetSequenceNumber(), 0);
+    ASSERT_EQ(cf_2_status.apply_point.GetLogIndex(), 30);
+    ASSERT_EQ(cf_2_status.apply_point.GetSequenceNumber(), 50);
 
     auto [smallest_applied_log_index_cf, smallest_applied_log_index, smallest_flushed_log_index_cf,
           smallest_flushed_log_index, smallest_flushed_seqno] =
-        rocksdb->GetLogIndexOfColumnFamilies().GetSmallestLogIndex(-1);
+        rocksdb->GetPointPairOfColumnFamilies()->GetCurrentSmallestPoint(-1);
 
     ASSERT_EQ(smallest_flushed_log_index, 0);
     ASSERT_EQ(smallest_flushed_seqno, 0);
@@ -242,8 +245,6 @@ TEST_F(FlushOldestCFTest, SimpleTest) {
     // last_flush_index   log_index    sequencenumber
     //                       0               0
 
-    auto gap = rocksdb->GetLogIndexOfColumnFamilies().GetPendingFlushGap();
-    ASSERT_EQ(gap, 30);
     flush_cf(1);
     sleep(5);  // sleep flush complete.
     // 1) 根据 cf 1 的 latest SequenceNumber = 49 查到对应的 log index 为 30. 设置 cf 1 的 flushed_log_index 和
@@ -393,33 +394,33 @@ TEST_F(FlushOldestCFTest, SimpleTest) {
     auto after_flush_size = rocksdb->GetCollector().GetSize();
     ASSERT_EQ(after_flush_size, 1);
 
-    auto& cf_0_status = rocksdb->GetLogIndexOfColumnFamilies().GetCFStatus(storage::kStringsCF);
-    ASSERT_EQ(cf_0_status.flushed_index.log_index, 30);
-    ASSERT_EQ(cf_0_status.flushed_index.seqno, 50);
-    ASSERT_EQ(cf_0_status.applied_index.log_index, 10);
-    ASSERT_EQ(cf_0_status.applied_index.seqno, 10);
+    auto& cf_0_status = rocksdb->GetPointPairOfColumnFamilies()->GetPointPair(storage::kStringsCF);
+    ASSERT_EQ(cf_0_status.flush_point.GetLogIndex(), 30);
+    ASSERT_EQ(cf_0_status.flush_point.GetSequenceNumber(), 50);
+    ASSERT_EQ(cf_0_status.apply_point.GetLogIndex(), 10);
+    ASSERT_EQ(cf_0_status.apply_point.GetSequenceNumber(), 10);
 
-    auto& cf_1_status = rocksdb->GetLogIndexOfColumnFamilies().GetCFStatus(storage::kHashesMetaCF);
-    ASSERT_EQ(cf_1_status.flushed_index.log_index, 30);
-    ASSERT_EQ(cf_1_status.flushed_index.seqno, 50);
-    ASSERT_EQ(cf_1_status.applied_index.log_index, 30);
-    ASSERT_EQ(cf_1_status.applied_index.seqno, 49);
+    auto& cf_1_status = rocksdb->GetPointPairOfColumnFamilies()->GetPointPair(storage::kHashesMetaCF);
+    ASSERT_EQ(cf_1_status.flush_point.GetLogIndex(), 30);
+    ASSERT_EQ(cf_1_status.flush_point.GetSequenceNumber(), 50);
+    ASSERT_EQ(cf_1_status.apply_point.GetLogIndex(), 30);
+    ASSERT_EQ(cf_1_status.apply_point.GetSequenceNumber(), 49);
 
-    auto& cf_2_status = rocksdb->GetLogIndexOfColumnFamilies().GetCFStatus(storage::kHashesDataCF);
-    ASSERT_EQ(cf_2_status.flushed_index.log_index, 30);
-    ASSERT_EQ(cf_2_status.flushed_index.seqno, 50);
-    ASSERT_EQ(cf_2_status.applied_index.log_index, 30);
-    ASSERT_EQ(cf_2_status.applied_index.seqno, 50);
+    auto& cf_2_status = rocksdb->GetPointPairOfColumnFamilies()->GetPointPair(storage::kHashesDataCF);
+    ASSERT_EQ(cf_2_status.flush_point.GetLogIndex(), 30);
+    ASSERT_EQ(cf_2_status.flush_point.GetSequenceNumber(), 50);
+    ASSERT_EQ(cf_2_status.apply_point.GetLogIndex(), 30);
+    ASSERT_EQ(cf_2_status.apply_point.GetSequenceNumber(), 50);
 
-    auto& last_flush_index = rocksdb->GetLogIndexOfColumnFamilies().GetLastFlushIndex();
+    auto& last_flush_index = rocksdb->GetPointPairOfColumnFamilies()->GetPersistedWatermark();
     ASSERT_EQ(last_flush_index.log_index.load(), 30);
     ASSERT_EQ(last_flush_index.seqno.load(), 50);
 
-    auto& cf_3_status = rocksdb->GetLogIndexOfColumnFamilies().GetCFStatus(storage::kSetsMetaCF);
-    ASSERT_EQ(cf_3_status.flushed_index.log_index, 30);
-    ASSERT_EQ(cf_3_status.flushed_index.seqno, 50);
-    ASSERT_EQ(cf_3_status.applied_index.log_index, 0);
-    ASSERT_EQ(cf_3_status.applied_index.seqno, 0);
+    auto& cf_3_status = rocksdb->GetPointPairOfColumnFamilies()->GetPointPair(storage::kSetsMetaCF);
+    ASSERT_EQ(cf_3_status.flush_point.GetLogIndex(), 30);
+    ASSERT_EQ(cf_3_status.flush_point.GetSequenceNumber(), 50);
+    ASSERT_EQ(cf_3_status.apply_point.GetLogIndex(), 0);
+    ASSERT_EQ(cf_3_status.apply_point.GetSequenceNumber(), 0);
   }
 
   {
@@ -435,37 +436,37 @@ TEST_F(FlushOldestCFTest, SimpleTest) {
     //
     // last_flush_index   log_index    sequencenumber
     //                       30              50
-    auto& last_flush_index = rocksdb->GetLogIndexOfColumnFamilies().GetLastFlushIndex();
+    auto& last_flush_index = rocksdb->GetPointPairOfColumnFamilies()->GetPersistedWatermark();
     ASSERT_EQ(last_flush_index.log_index.load(), 30);
     ASSERT_EQ(last_flush_index.seqno.load(), 50);
 
-    auto& cf_0_status = rocksdb->GetLogIndexOfColumnFamilies().GetCFStatus(storage::kStringsCF);
-    ASSERT_EQ(cf_0_status.flushed_index.log_index, 30);
-    ASSERT_EQ(cf_0_status.flushed_index.seqno, 50);
-    ASSERT_EQ(cf_0_status.applied_index.log_index, 35);
-    ASSERT_EQ(cf_0_status.applied_index.seqno, 55);
+    auto& cf_0_status = rocksdb->GetPointPairOfColumnFamilies()->GetPointPair(storage::kStringsCF);
+    ASSERT_EQ(cf_0_status.flush_point.log_index, 30);
+    ASSERT_EQ(cf_0_status.flush_point.seqno, 50);
+    ASSERT_EQ(cf_0_status.apply_point.log_index, 35);
+    ASSERT_EQ(cf_0_status.apply_point.seqno, 55);
 
-    auto& cf_1_status = rocksdb->GetLogIndexOfColumnFamilies().GetCFStatus(storage::kHashesMetaCF);
-    ASSERT_EQ(cf_1_status.flushed_index.log_index, 30);
-    ASSERT_EQ(cf_1_status.flushed_index.seqno, 50);
-    ASSERT_EQ(cf_1_status.applied_index.log_index, 30);
-    ASSERT_EQ(cf_1_status.applied_index.seqno, 49);
+    auto& cf_1_status = rocksdb->GetPointPairOfColumnFamilies()->GetPointPair(storage::kHashesMetaCF);
+    ASSERT_EQ(cf_1_status.flush_point.log_index, 30);
+    ASSERT_EQ(cf_1_status.flush_point.seqno, 50);
+    ASSERT_EQ(cf_1_status.apply_point.log_index, 30);
+    ASSERT_EQ(cf_1_status.apply_point.seqno, 49);
 
-    auto& cf_2_status = rocksdb->GetLogIndexOfColumnFamilies().GetCFStatus(storage::kHashesDataCF);
-    ASSERT_EQ(cf_2_status.flushed_index.log_index, 30);
-    ASSERT_EQ(cf_2_status.flushed_index.seqno, 50);
-    ASSERT_EQ(cf_2_status.applied_index.log_index, 30);
-    ASSERT_EQ(cf_2_status.applied_index.seqno, 50);
+    auto& cf_2_status = rocksdb->GetPointPairOfColumnFamilies()->GetPointPair(storage::kHashesDataCF);
+    ASSERT_EQ(cf_2_status.flush_point.log_index, 30);
+    ASSERT_EQ(cf_2_status.flush_point.seqno, 50);
+    ASSERT_EQ(cf_2_status.apply_point.log_index, 30);
+    ASSERT_EQ(cf_2_status.apply_point.seqno, 50);
 
-    auto& cf_3_status = rocksdb->GetLogIndexOfColumnFamilies().GetCFStatus(storage::kSetsMetaCF);
-    ASSERT_EQ(cf_3_status.flushed_index.log_index, 30);
-    ASSERT_EQ(cf_3_status.flushed_index.seqno, 50);
-    ASSERT_EQ(cf_3_status.applied_index.log_index, 0);
-    ASSERT_EQ(cf_3_status.applied_index.seqno, 0);
+    auto& cf_3_status = rocksdb->GetPointPairOfColumnFamilies()->GetPointPair(storage::kSetsMetaCF);
+    ASSERT_EQ(cf_3_status.flush_point.log_index, 30);
+    ASSERT_EQ(cf_3_status.flush_point.seqno, 50);
+    ASSERT_EQ(cf_3_status.apply_point.log_index, 0);
+    ASSERT_EQ(cf_3_status.apply_point.seqno, 0);
 
     auto [smallest_applied_log_index_cf, smallest_applied_log_index, smallest_flushed_log_index_cf,
           smallest_flushed_log_index, smallest_flushed_seqno] =
-        rocksdb->GetLogIndexOfColumnFamilies().GetSmallestLogIndex(-1);
+        rocksdb->GetPointPairOfColumnFamilies()->GetCurrentSmallestPoint(-1);
 
     // 除了 cf 0 之外, 其余的 cf 都没有未持久化数据, 所以不在我们统计范围之内.
     ASSERT_EQ(smallest_applied_log_index_cf, 0);

--- a/src/storage/tests/log_index_test.cc
+++ b/src/storage/tests/log_index_test.cc
@@ -104,7 +104,6 @@ class LogIndexTest : public ::testing::Test {
     options_.append_log_function = [this](const pikiwidb::Binlog& log, std::promise<rocksdb::Status>&& promise) {
       log_queue_.AppendLog(log, std::move(promise));
     };
-    options_.do_snapshot_function = [](int64_t log_index, bool sync) {};
   }
   ~LogIndexTest() override { DeleteFiles(db_path_.c_str()); }
 


### PR DESCRIPTION
每一个 rocksdb 依然维护自己的队列信息记录自己的 seq 和 全局的 logindex 的对应关系。
每一个 rocksdb 的flush 和 apply 点位维护在 storag中， rocksdb 中仅持有对应的指针。
通过 storage 获取到所有 rocksdb 中最小的 flush 点位，作为日志的截断点。