### PR TITLE
feat: add some list raft commands

### DIFF
--- a/src/storage/src/redis_lists.cc
+++ b/src/storage/src/redis_lists.cc
@@ -161,7 +161,7 @@ Status Redis::LInsert(const Slice& key, const BeforeOrAfter& before_or_after, co
       for (iter->Seek(start_data_key.Encode()); iter->Valid() && current_index < parsed_lists_meta_value.RightIndex();
            iter->Next(), current_index++) {
         ParsedBaseDataValue parsed_value(iter->value());
-        if (pivot.compare(parsed_value.UserValue().ToString()) == 0) {
+        if (pivot == parsed_value.UserValue().ToString()) {
           find_pivot = true;
           pivot_index = current_index;
           break;

--- a/src/storage/src/redis_lists.cc
+++ b/src/storage/src/redis_lists.cc
@@ -622,6 +622,7 @@ Status Redis::LRem(const Slice& key, int64_t count, const Slice& value, uint64_t
 
 Status Redis::LSet(const Slice& key, int64_t index, const Slice& value) {
   uint32_t statistic = 0;
+  auto batch = Batch::CreateBatch(this);
   ScopeRecordLock l(lock_mgr_, key);
   std::string meta_value;
 
@@ -642,10 +643,10 @@ Status Redis::LSet(const Slice& key, int64_t index, const Slice& value) {
       }
       ListsDataKey lists_data_key(key, version, target_index);
       BaseDataValue i_val(value);
-      s = db_->Put(default_write_options_, handles_[kListsDataCF], lists_data_key.Encode(), i_val.Encode());
+      batch->Put(kListsDataCF, lists_data_key.Encode(), i_val.Encode());
       statistic++;
       UpdateSpecificKeyStatistics(DataType::kLists, key.ToString(), statistic);
-      return s;
+      return batch->Commit();
     }
   }
   return s;


### PR DESCRIPTION
#280 
use customized batch interface to replace `rocksdb::Batch` in some list commands, such as `LInsert`, `LPushx`, `LRem`, `LSet`, `LTrim`.