### PR TITLE
fix: handle uninitialized and non-leader states in Raft cluster mode

### DIFF
--- a/src/base_cmd.cc
+++ b/src/base_cmd.cc
@@ -35,14 +35,15 @@ void BaseCmd::Execute(PClient* client) {
   DEBUG("execute command: {}", client->CmdName());
 
   if (g_config.use_raft.load()) {
-    // 1. 如果 PRAFT 还没有初始化，对于读写命令，应该返回客户端一个初始化未完成的提示信息。
+    // 1. If PRAFT is not initialized yet, return an error message to the client for both read and write commands.
     if (!PRAFT.IsInitialized() && (HasFlag(kCmdFlagsReadonly) || HasFlag(kCmdFlagsWrite))) {
       DEBUG("drop command: {}", client->CmdName());
       return client->SetRes(CmdRes::kErrOther, "PRAFT is not initialized");
     }
 
-    // 2. 如果 PRAFT 初始化完成了，对于写命令，如果自身的角色不是 leader，返回一个重定向的信息。
-    if (!PRAFT.IsLeader() && HasFlag(kCmdFlagsWrite)) {
+    // 2. If PRAFT is initialized and the current node is not the leader, return a redirection message for write
+    // commands.
+    if (HasFlag(kCmdFlagsWrite) && !PRAFT.IsLeader()) {
       return client->SetRes(CmdRes::kErrOther, fmt::format("MOVED {}", PRAFT.GetLeaderAddress()));
     }
   }

--- a/src/base_cmd.cc
+++ b/src/base_cmd.cc
@@ -74,13 +74,8 @@ std::string BaseCmd::Name() const { return name_; }
 uint32_t BaseCmd::GetCmdID() const { return cmd_id_; }
 
 bool BaseCmd::IsAllowedPreRaftInit(const std::string& cmd_name) const {
-  // Allow all commands if Raft is not used or if Raft is initialized
-  if (!g_config.use_raft.load() || PRAFT.IsInitialized()) {
-    return true;
-  }
-
-  // Allow only specific commands if Raft is used but not initialized
-  return kPreRaftInitCmds.count(cmd_name) != 0;
+  // Allow only specific commands if Raft is not initialized
+  return PRAFT.IsInitialized() || kPreRaftInitCmds.count(cmd_name) != 0;
 }
 
 // BaseCmdGroup

--- a/src/base_cmd.cc
+++ b/src/base_cmd.cc
@@ -7,8 +7,10 @@
 
 #include "base_cmd.h"
 #include "common.h"
+#include "config.h"
 #include "log.h"
 #include "pikiwidb.h"
+#include "praft/praft.h"
 
 namespace pikiwidb {
 
@@ -31,6 +33,11 @@ std::vector<std::string> BaseCmd::CurrentKey(PClient* client) const { return std
 
 void BaseCmd::Execute(PClient* client) {
   DEBUG("execute command: {}", client->CmdName());
+
+  if (!IsAllowedPreRaftInit(client->CmdName())) {
+    DEBUG("drop command: {}", client->CmdName());
+    return client->SetRes(CmdRes::kErrOther, "NOCLUSTER No Raft Cluster");
+  }
 
   auto dbIndex = client->GetCurrentDB();
   if (!HasFlag(kCmdFlagsExclusive)) {
@@ -65,6 +72,16 @@ std::string BaseCmd::Name() const { return name_; }
 // void BaseCommand::SetResp(const std::shared_ptr<std::string>& resp) { resp_ = resp; }
 // std::shared_ptr<std::string> BaseCommand::GetResp() { return resp_.lock(); }
 uint32_t BaseCmd::GetCmdID() const { return cmd_id_; }
+
+bool BaseCmd::IsAllowedPreRaftInit(const std::string& cmd_name) const {
+  // Allow all commands if Raft is not used or if Raft is initialized
+  if (!g_config.use_raft.load() || PRAFT.IsInitialized()) {
+    return true;
+  }
+
+  // Allow only specific commands if Raft is used but not initialized
+  return kPreRaftInitCmds.count(cmd_name) != 0;
+}
 
 // BaseCmdGroup
 BaseCmdGroup::BaseCmdGroup(const std::string& name, uint32_t flag) : BaseCmdGroup(name, -2, flag) {}

--- a/src/base_cmd.cc
+++ b/src/base_cmd.cc
@@ -34,9 +34,17 @@ std::vector<std::string> BaseCmd::CurrentKey(PClient* client) const { return std
 void BaseCmd::Execute(PClient* client) {
   DEBUG("execute command: {}", client->CmdName());
 
-  if (!IsAllowedPreRaftInit(client->CmdName())) {
-    DEBUG("drop command: {}", client->CmdName());
-    return client->SetRes(CmdRes::kErrOther, "NOCLUSTER No Raft Cluster");
+  if (g_config.use_raft.load()) {
+    // 1. 如果 PRAFT 还没有初始化，对于读写命令，应该返回客户端一个初始化未完成的提示信息。
+    if (!PRAFT.IsInitialized() && (HasFlag(kCmdFlagsReadonly) || HasFlag(kCmdFlagsWrite))) {
+      DEBUG("drop command: {}", client->CmdName());
+      return client->SetRes(CmdRes::kErrOther, "PRAFT is not initialized");
+    }
+
+    // 2. 如果 PRAFT 初始化完成了，对于写命令，如果自身的角色不是 leader，返回一个重定向的信息。
+    if (!PRAFT.IsLeader() && HasFlag(kCmdFlagsWrite)) {
+      return client->SetRes(CmdRes::kErrOther, fmt::format("MOVED {}", PRAFT.GetLeaderAddress()));
+    }
   }
 
   auto dbIndex = client->GetCurrentDB();
@@ -72,11 +80,6 @@ std::string BaseCmd::Name() const { return name_; }
 // void BaseCommand::SetResp(const std::shared_ptr<std::string>& resp) { resp_ = resp; }
 // std::shared_ptr<std::string> BaseCommand::GetResp() { return resp_.lock(); }
 uint32_t BaseCmd::GetCmdID() const { return cmd_id_; }
-
-bool BaseCmd::IsAllowedPreRaftInit(const std::string& cmd_name) const {
-  // Allow only specific commands if Raft is not initialized
-  return PRAFT.IsInitialized() || kPreRaftInitCmds.count(cmd_name) != 0;
-}
 
 // BaseCmdGroup
 BaseCmdGroup::BaseCmdGroup(const std::string& name, uint32_t flag) : BaseCmdGroup(name, -2, flag) {}

--- a/src/base_cmd.h
+++ b/src/base_cmd.h
@@ -10,7 +10,6 @@
 #include <atomic>
 #include <map>
 #include <memory>
-#include <set>
 #include <span>
 #include <string>
 #include <unordered_map>
@@ -161,10 +160,6 @@ const std::string kCmdNameZRank = "zrank";
 const std::string kCmdNameZRevrank = "zrevrank";
 const std::string kCmdNameZRem = "zrem";
 const std::string kCmdNameZIncrby = "zincrby";
-
-// If Raft is used but not initialized, only allow specific commands
-const std::set<std::string> kPreRaftInitCmds = {kCmdNameRaftCluster, kCmdNamePing, kCmdNameConfig,
-                                                kCmdNameAuth,        kCmdNameInfo, kCmdNameShutdown};
 
 enum CmdFlags {
   kCmdFlagsWrite = (1 << 0),             // May modify the dataset
@@ -319,8 +314,6 @@ class BaseCmd : public std::enable_shared_from_this<BaseCmd> {
   //  std::shared_ptr<std::string> GetResp();
 
   uint32_t GetCmdID() const;
-
-  bool IsAllowedPreRaftInit(const std::string& cmd_name) const;
 
  protected:
   // Execute a specific command

--- a/src/base_cmd.h
+++ b/src/base_cmd.h
@@ -10,6 +10,7 @@
 #include <atomic>
 #include <map>
 #include <memory>
+#include <set>
 #include <span>
 #include <string>
 #include <unordered_map>
@@ -160,6 +161,10 @@ const std::string kCmdNameZRank = "zrank";
 const std::string kCmdNameZRevrank = "zrevrank";
 const std::string kCmdNameZRem = "zrem";
 const std::string kCmdNameZIncrby = "zincrby";
+
+// If Raft is used but not initialized, only allow specific commands
+const std::set<std::string> kPreRaftInitCmds = {kCmdNameRaftCluster, kCmdNamePing, kCmdNameConfig,
+                                                kCmdNameAuth,        kCmdNameInfo, kCmdNameShutdown};
 
 enum CmdFlags {
   kCmdFlagsWrite = (1 << 0),             // May modify the dataset
@@ -314,6 +319,8 @@ class BaseCmd : public std::enable_shared_from_this<BaseCmd> {
   //  std::shared_ptr<std::string> GetResp();
 
   uint32_t GetCmdID() const;
+
+  bool IsAllowedPreRaftInit(const std::string& cmd_name) const;
 
  protected:
   // Execute a specific command

--- a/src/cmd_admin.cc
+++ b/src/cmd_admin.cc
@@ -129,8 +129,7 @@ void ShutdownCmd::DoCmd(PClient* client) {
   client->SetRes(CmdRes::kNone);
 }
 
-PingCmd::PingCmd(const std::string& name, int16_t arity)
-    : BaseCmd(name, arity, kCmdFlagsWrite, kAclCategoryWrite | kAclCategoryList) {}
+PingCmd::PingCmd(const std::string& name, int16_t arity) : BaseCmd(name, arity, kCmdFlagsFast, kAclCategoryFast) {}
 
 bool PingCmd::DoInitial(PClient* client) { return true; }
 

--- a/src/cmd_kv.cc
+++ b/src/cmd_kv.cc
@@ -532,7 +532,7 @@ void SetNXCmd::DoCmd(PClient* client) {
 }
 
 GetBitCmd::GetBitCmd(const std::string& name, int16_t arity)
-    : BaseCmd(name, arity, kCmdFlagsWrite, kAclCategoryWrite | kAclCategoryString) {}
+    : BaseCmd(name, arity, kCmdFlagsReadonly | kCmdFlagsFast, kAclCategoryRead | kAclCategoryBitmap) {}
 
 bool GetBitCmd::DoInitial(PClient* client) {
   client->SetKey(client->argv_[1]);

--- a/tests/consistency_test.go
+++ b/tests/consistency_test.go
@@ -47,11 +47,10 @@ var _ = Describe("Consistency", Ordered, func() {
 			if i == 0 {
 				leader = s.NewClient()
 				Expect(leader).NotTo(BeNil())
-				// Expect(leader.FlushDB(ctx).Err()).NotTo(HaveOccurred())
+				Expect(leader.FlushDB(ctx).Err().Error()).To(Equal("ERR PRAFT is not initialized"))
 			} else {
 				c := s.NewClient()
 				Expect(c).NotTo(BeNil())
-				// Expect(c.FlushDB(ctx).Err()).NotTo(HaveOccurred())
 				Expect(c.FlushDB(ctx).Err().Error()).To(Equal("ERR PRAFT is not initialized"))
 				followers = append(followers, c)
 			}

--- a/tests/consistency_test.go
+++ b/tests/consistency_test.go
@@ -52,6 +52,7 @@ var _ = Describe("Consistency", Ordered, func() {
 				c := s.NewClient()
 				Expect(c).NotTo(BeNil())
 				// Expect(c.FlushDB(ctx).Err()).NotTo(HaveOccurred())
+				Expect(c.FlushDB(ctx).Err().Error()).To(Equal("ERR PRAFT is not initialized"))
 				followers = append(followers, c)
 			}
 		}
@@ -92,11 +93,11 @@ var _ = Describe("Consistency", Ordered, func() {
 			if i == 0 {
 				leader = s.NewClient()
 				Expect(leader).NotTo(BeNil())
-				// Expect(leader.FlushDB(ctx).Err()).NotTo(HaveOccurred())
+				Expect(leader.FlushDB(ctx).Err()).NotTo(HaveOccurred())
 			} else {
 				c := s.NewClient()
 				Expect(c).NotTo(BeNil())
-				//Expect(c.FlushDB(ctx).Err().Error()).To(Equal("ERR MOVED 127.0.0.1:12111"))
+				Expect(c.FlushDB(ctx).Err().Error()).To(Equal("ERR MOVED 127.0.0.1:12111"))
 				followers = append(followers, c)
 			}
 		}

--- a/tests/consistency_test.go
+++ b/tests/consistency_test.go
@@ -47,11 +47,11 @@ var _ = Describe("Consistency", Ordered, func() {
 			if i == 0 {
 				leader = s.NewClient()
 				Expect(leader).NotTo(BeNil())
-				Expect(leader.FlushDB(ctx).Err()).NotTo(HaveOccurred())
+				// Expect(leader.FlushDB(ctx).Err()).NotTo(HaveOccurred())
 			} else {
 				c := s.NewClient()
 				Expect(c).NotTo(BeNil())
-				Expect(c.FlushDB(ctx).Err()).NotTo(HaveOccurred())
+				// Expect(c.FlushDB(ctx).Err()).NotTo(HaveOccurred())
 				followers = append(followers, c)
 			}
 		}
@@ -92,7 +92,7 @@ var _ = Describe("Consistency", Ordered, func() {
 			if i == 0 {
 				leader = s.NewClient()
 				Expect(leader).NotTo(BeNil())
-				Expect(leader.FlushDB(ctx).Err()).NotTo(HaveOccurred())
+				// Expect(leader.FlushDB(ctx).Err()).NotTo(HaveOccurred())
 			} else {
 				c := s.NewClient()
 				Expect(c).NotTo(BeNil())


### PR DESCRIPTION
#307 
read/write commands are now dropped if raft has not been initialized in raft mode, and an error message 'NOCLUSTER No Raft Cluster' is returned to the client. This change prevents the system from crashing due to failed assertions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新功能**
  - 在执行命令之前添加了PRAFT初始化和领导状态检查逻辑。

- **测试**
  - 修改了与数据库刷新相关的测试用例，以增加对特定错误消息的验证逻辑。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->