### PR TITLE
fix: bug when installing braft

### DIFF
--- a/cmake/braft.cmake
+++ b/cmake/braft.cmake
@@ -18,6 +18,7 @@ ExternalProject_Add(
         DEPENDS brpc
         GIT_REPOSITORY "https://github.com/pikiwidb/braft.git"
         GIT_TAG master
+        GIT_SHALLOW true
         PREFIX ${BRAFT_SOURCES_DIR}
         UPDATE_COMMAND ""
         CMAKE_ARGS -DCMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER}
@@ -38,7 +39,7 @@ ExternalProject_Add(
         -DCMAKE_BUILD_TYPE:STRING=${THIRD_PARTY_BUILD_TYPE}
         BUILD_IN_SOURCE 1
         BUILD_COMMAND $(MAKE) -j ${CPU_CORE} braft-static
-        INSTALL_COMMAND mkdir -p ${BRAFT_INSTALL_DIR}/lib/ COMMAND cp ${BRAFT_SOURCES_DIR}/src/extern_braft/output/lib/libbraft.a ${BRAFT_LIBRARIES} COMMAND cp -r ${BRAFT_SOURCES_DIR}/src/extern_braft/output/include ${BRAFT_INCLUDE_DIR}/
+        INSTALL_COMMAND mkdir -p ${BRAFT_INSTALL_DIR}/lib/ COMMAND cp ${BRAFT_SOURCES_DIR}/src/extern_braft/output/lib/libbraft.a ${BRAFT_LIBRARIES} COMMAND rm -rf ${BRAFT_INCLUDE_DIR} COMMAND cp -r ${BRAFT_SOURCES_DIR}/src/extern_braft/output/include ${BRAFT_INCLUDE_DIR}
 )
 ADD_DEPENDENCIES(extern_braft brpc)
 ADD_LIBRARY(braft STATIC IMPORTED GLOBAL)

--- a/cmake/brpc.cmake
+++ b/cmake/brpc.cmake
@@ -41,7 +41,6 @@ EXTERNALPROJECT_ADD(
         -DCMAKE_BUILD_TYPE:STRING=${THIRD_PARTY_BUILD_TYPE}
         BUILD_IN_SOURCE 1
         BUILD_COMMAND $(MAKE) -j ${CPU_CORE} brpc-static
-        INSTALL_COMMAND mkdir -p ${BRPC_INSTALL_DIR}/lib/ COMMAND cp ${BRPC_SOURCES_DIR}/src/extern_brpc/output/lib/libbrpc.a ${BRPC_LIBRARIES} COMMAND rm -rf ${BRPC_INCLUDE_DIR} COMMAND cp -r ${BRPC_SOURCES_DIR}/src/extern_brpc/output/include ${BRPC_INCLUDE_DIR}
 )
 ADD_DEPENDENCIES(extern_brpc ssl crypto zlib protobuf leveldb gflags)
 ADD_LIBRARY(brpc STATIC IMPORTED GLOBAL)

--- a/cmake/brpc.cmake
+++ b/cmake/brpc.cmake
@@ -41,7 +41,7 @@ EXTERNALPROJECT_ADD(
         -DCMAKE_BUILD_TYPE:STRING=${THIRD_PARTY_BUILD_TYPE}
         BUILD_IN_SOURCE 1
         BUILD_COMMAND $(MAKE) -j ${CPU_CORE} brpc-static
-        INSTALL_COMMAND mkdir -p ${BRPC_INSTALL_DIR}/lib/ COMMAND cp ${BRPC_SOURCES_DIR}/src/extern_brpc/output/lib/libbrpc.a ${BRPC_LIBRARIES} COMMAND cp -r ${BRPC_SOURCES_DIR}/src/extern_brpc/output/include ${BRPC_INCLUDE_DIR}/
+        INSTALL_COMMAND mkdir -p ${BRPC_INSTALL_DIR}/lib/ COMMAND cp ${BRPC_SOURCES_DIR}/src/extern_brpc/output/lib/libbrpc.a ${BRPC_LIBRARIES} COMMAND rm -rf ${BRPC_INCLUDE_DIR} COMMAND cp -r ${BRPC_SOURCES_DIR}/src/extern_brpc/output/include ${BRPC_INCLUDE_DIR}
 )
 ADD_DEPENDENCIES(extern_brpc ssl crypto zlib protobuf leveldb gflags)
 ADD_LIBRARY(brpc STATIC IMPORTED GLOBAL)

--- a/cmake/zlib.cmake
+++ b/cmake/zlib.cmake
@@ -15,6 +15,7 @@ ExternalProject_Add(
         ${EXTERNAL_PROJECT_LOG_ARGS}
         GIT_REPOSITORY  "https://github.com/madler/zlib.git"
         GIT_TAG         "v1.2.8"
+        GIT_SHALLOW true
         PREFIX          ${ZLIB_SOURCES_DIR}
         UPDATE_COMMAND  ""
         CMAKE_ARGS      -DCMAKE_C_COMPILER=${CMAKE_C_COMPILER}


### PR DESCRIPTION
Fix the small bug when installing braft. #224
Meanwhile, add `GIT_SHALLOW` to speed up the `git clone` process.