### PR TITLE
fix: fix a bug of not find gflags

### DIFF
--- a/cmake/gflags.cmake
+++ b/cmake/gflags.cmake
@@ -5,6 +5,9 @@
 
 INCLUDE_GUARD()
 
+SET(GFLAGS_BUILD_TYPE "Release")
+SET(CMAKE_BUILD_TYPE ${GFLAGS_BUILD_TYPE})
+
 FetchContent_Declare(gflags
   URL https://github.com/gflags/gflags/archive/v2.2.2.zip
   URL_HASH SHA256=19713a36c9f32b33df59d1c79b4958434cb005b5b47dc5400a7a4b078111d9b5
@@ -21,6 +24,8 @@ FIND_PACKAGE(Threads REQUIRED)
 
 TARGET_LINK_LIBRARIES(gflags_static Threads::Threads)
 
-SET(GFLAGS_INCLUDE_PATH ${CMAKE_CURRENT_BINARY_DIR}/_deps/gflags-build/include)
-SET(GFLAGS_LIBRARY ${CMAKE_CURRENT_BINARY_DIR}/_deps/gflags-build/libgflags.a)
-SET(GFLAGS_LIB ${CMAKE_CURRENT_BINARY_DIR}/_deps/gflags-build/libgflags.a)
+SET(GFLAGS_INCLUDE_PATH ${CMAKE_CURRENT_BINARY_DIR}/_deps/gflags-build/include CACHE PATH "" FORCE)
+SET(GFLAGS_LIBRARY ${CMAKE_CURRENT_BINARY_DIR}/_deps/gflags-build/libgflags.a CACHE PATH "" FORCE)
+SET(GFLAGS_LIB ${CMAKE_CURRENT_BINARY_DIR}/_deps/gflags-build/libgflags.a CACHE PATH "" FORCE)
+
+SET(CMAKE_BUILD_TYPE ${THIRD_PARTY_BUILD_TYPE})


### PR DESCRIPTION
release 模式下，生成的 gflags 库名称为 libgflags.a，debug 模式下，生成的 gflags 库名称为 libgflags_debug.a。在 brpc 里面，它的 find_package 是按照 release 模式的名字寻找的。因此，在 debug 模式下会出现找不到 gflags 库，这里考虑的是 debug 模式下也不会进入 gflags 库中，所以始终按照 release 模式编译。如果大家有更好的解决办法，欢迎找我交流讨论。
![5a5d4e953dcf9f8b8da4d41a457e83f](https://github.com/OpenAtomFoundation/pikiwidb/assets/62509266/67a49b36-fdda-47ca-a46f-e8ccc76f1fc6)
