### PR TITLE
feat: add info section: server stats cpu commandstats

### DIFF
--- a/src/client.cc
+++ b/src/client.cc
@@ -672,4 +672,6 @@ void PClient::SetKey(std::vector<std::string>& names) {
 
 std::unordered_map<std::string, CommandStatistics>* PClient::GetCommandStatMap() { return &cmdstat_map_; }
 
+std::shared_ptr<TimeStat> PClient::GetTimeStat() { return time_stat_; }
+
 }  // namespace pikiwidb

--- a/src/client.cc
+++ b/src/client.cc
@@ -357,7 +357,8 @@ int PClient::handlePacket(const char* start, int bytes) {
   //  executeCommand();
   //    return static_cast<int>(ptr - start);
   //  }
-  time_stat_->enqueue_ts_ = pstd::NowMicros();
+  auto now = std::chrono::steady_clock::now();
+  time_stat_->SetEnqueueTs(now);
   g_pikiwidb->SubmitFast(std::make_shared<CmdThreadPoolTask>(shared_from_this()));
 
   // check transaction

--- a/src/client.cc
+++ b/src/client.cc
@@ -17,7 +17,11 @@
 
 #include "base_cmd.h"
 #include "config.h"
+#include "env.h"
 #include "pikiwidb.h"
+#include "pstd_string.h"
+#include "slow_log.h"
+#include "store.h"
 
 namespace pikiwidb {
 
@@ -353,7 +357,7 @@ int PClient::handlePacket(const char* start, int bytes) {
   //  executeCommand();
   //    return static_cast<int>(ptr - start);
   //  }
-
+  time_stat_->enqueue_ts_ = pstd::NowMicros();
   g_pikiwidb->SubmitFast(std::make_shared<CmdThreadPoolTask>(shared_from_this()));
 
   // check transaction
@@ -424,6 +428,7 @@ PClient* PClient::Current() { return s_current; }
 PClient::PClient() : parser_(params_) {
   auth_ = false;
   reset();
+  time_stat_.reset(new TimeStat());
 }
 
 void PClient::OnConnect() {
@@ -664,5 +669,7 @@ void PClient::FeedMonitors(const std::vector<std::string>& params) {
 void PClient::SetKey(std::vector<std::string>& names) {
   keys_ = std::move(names);  // use std::move clear copy expense
 }
+
+std::unordered_map<std::string, CommandStatistics>* PClient::GetCommandStatMap() { return &cmdstat_map_; }
 
 }  // namespace pikiwidb

--- a/src/client.h
+++ b/src/client.h
@@ -25,10 +25,8 @@ namespace pikiwidb {
 struct CommandStatistics {
   CommandStatistics() = default;
   CommandStatistics(const CommandStatistics& other)
-  :cmd_count_(other.cmd_count_.load()), cmd_time_consuming_(other.cmd_time_consuming_.load()) {
-    cmd_time_consuming_.store(other.cmd_time_consuming_.load());
-    cmd_count_.store(other.cmd_count_.load());
-  }
+      : cmd_count_(other.cmd_count_.load()), cmd_time_consuming_(other.cmd_time_consuming_.load()) {}
+
   std::atomic<uint64_t> cmd_count_ = 0;
   std::atomic<uint64_t> cmd_time_consuming_ = 0;
 };

--- a/src/client.h
+++ b/src/client.h
@@ -24,11 +24,11 @@ namespace pikiwidb {
 struct CommandStatistics {
   CommandStatistics() = default;
   CommandStatistics(const CommandStatistics& other) {
-    cmd_time_consuming.store(other.cmd_time_consuming.load());
-    cmd_count.store(other.cmd_count.load());
+    cmd_time_consuming_.store(other.cmd_time_consuming_.load());
+    cmd_count_.store(other.cmd_count_.load());
   }
-  std::atomic<uint64_t> cmd_count = 0;
-  std::atomic<uint64_t> cmd_time_consuming = 0;
+  std::atomic<uint64_t> cmd_count_ = 0;
+  std::atomic<uint64_t> cmd_time_consuming_ = 0;
 };
 
 struct TimeStat {
@@ -38,7 +38,10 @@ struct TimeStat {
     process_done_ts_ = 0;
   }
 
-  uint64_t total_time() const { return process_done_ts_ > enqueue_ts_ ? process_done_ts_ - enqueue_ts_ : 0; }
+  uint64_t GetTotalTime() const { return process_done_ts_ > enqueue_ts_ ? process_done_ts_ - enqueue_ts_ : 0; }
+  void SetEnqueueTs(uint64_t now_time) { enqueue_ts_ = now_time; }
+  void SetDequeueTs(uint64_t now_time) { dequeue_ts_ = now_time; }
+  void SetProcessDoneTs(uint64_t now_time) { process_done_ts_ = now_time; }
 
   uint64_t enqueue_ts_;
   uint64_t dequeue_ts_;
@@ -261,8 +264,8 @@ class PClient : public std::enable_shared_from_this<PClient>, public CmdRes {
   std::span<std::string> argv_;
 
   // Info Commandstats used
-  std::shared_ptr<TimeStat> time_stat_;
   std::unordered_map<std::string, CommandStatistics>* GetCommandStatMap();
+  std::shared_ptr<TimeStat> GetTimeStat();
 
   //  std::shared_ptr<TcpConnection> getTcpConnection() const { return tcp_connection_.lock(); }
   int handlePacket(const char*, int);
@@ -324,5 +327,6 @@ class PClient : public std::enable_shared_from_this<PClient>, public CmdRes {
    * Info Commandstats used
    */
   std::unordered_map<std::string, CommandStatistics> cmdstat_map_;
+  std::shared_ptr<TimeStat> time_stat_;
 };
 }  // namespace pikiwidb

--- a/src/client.h
+++ b/src/client.h
@@ -52,9 +52,9 @@ struct TimeStat {
   void SetDequeueTs(TimePoint now_time) { dequeue_ts_ = now_time; }
   void SetProcessDoneTs(TimePoint now_time) { process_done_ts_ = now_time; }
 
-  TimePoint enqueue_ts_;
-  TimePoint dequeue_ts_;
-  TimePoint process_done_ts_;
+  TimePoint enqueue_ts_ = TimePoint::min();
+  TimePoint dequeue_ts_ = TimePoint::min();
+  TimePoint process_done_ts_ = TimePoint::min();
 };
 
 class CmdRes {

--- a/src/client.h
+++ b/src/client.h
@@ -24,7 +24,8 @@ namespace pikiwidb {
 
 struct CommandStatistics {
   CommandStatistics() = default;
-  CommandStatistics(const CommandStatistics& other) {
+  CommandStatistics(const CommandStatistics& other)
+  :cmd_count_(other.cmd_count_.load()), cmd_time_consuming_(other.cmd_time_consuming_.load()) {
     cmd_time_consuming_.store(other.cmd_time_consuming_.load());
     cmd_count_.store(other.cmd_count_.load());
   }

--- a/src/cmd_admin.cc
+++ b/src/cmd_admin.cc
@@ -189,20 +189,9 @@ bool InfoCmd::DoInitial(PClient* client) {
   }
 
   const auto& argv_ = client->argv_;
-  if (strcasecmp(argv_[1].data(), kAllSection.data()) == 0) {
-    info_section_ = kInfoAll;
-  } else if (strcasecmp(argv_[1].data(), kServerSection.data()) == 0) {
-    info_section_ = kInfoServer;
-  } else if (strcasecmp(argv_[1].data(), kStatsSection.data()) == 0) {
-    info_section_ = kInfoStats;
-  } else if (strcasecmp(argv_[1].data(), kCPUSection.data()) == 0) {
-    info_section_ = kInfoCPU;
-  } else if (strcasecmp(argv_[1].data(), kDataSection.data()) == 0) {
-    info_section_ = kInfoData;
-  } else if (strcasecmp(argv_[1].data(), kRaftSection.data()) == 0) {
-    info_section_ = kInfoRaft;
-  } else if (strcasecmp(argv_[1].data(), kCommandStatsSection.data()) == 0) {
-    info_section_ = kInfoCommandStats;
+  auto it = sectionMap.find(argv_[1].data());
+  if (it != sectionMap.end()) {
+    info_section_ = it->second;
   }
 
   if (argc != 2) {

--- a/src/cmd_admin.cc
+++ b/src/cmd_admin.cc
@@ -179,10 +179,6 @@ InfoCmd::InfoCmd(const std::string& name, int16_t arity) : BaseCmd(name, arity, 
 
 bool InfoCmd::DoInitial(PClient* client) {
   size_t argc = client->argv_.size();
-  if (argc > 4) {
-    client->SetRes(CmdRes::kSyntaxErr);
-    return false;
-  }
   if (argc == 1) {
     info_section_ = kInfo;
     return true;
@@ -268,13 +264,13 @@ void InfoCmd::DoCmd(PClient* client) {
 */
 void InfoCmd::InfoRaft(std::string& message) {
   if (!PRAFT.IsInitialized()) {
-    message += "-ERR:Don't already cluster member \r\n";
+    message += "-ERR Don't already cluster member\r\n";
     return;
   }
 
   auto node_status = PRAFT.GetNodeStatus();
   if (node_status.state == braft::State::STATE_END) {
-    message += "-ERR:Node is not initialized \r\n";
+    message += "-ERR Node is not initialized\r\n";
     return;
   }
 
@@ -296,7 +292,7 @@ void InfoCmd::InfoRaft(std::string& message) {
     std::vector<braft::PeerId> peers;
     auto status = PRAFT.GetListPeers(&peers);
     if (!status.ok()) {
-      tmp_stream << "-ERR:" << status.error_str();
+      tmp_stream << "-ERR " << status.error_str()<<"\r\n";
       return;
     }
 

--- a/src/cmd_admin.cc
+++ b/src/cmd_admin.cc
@@ -162,21 +162,6 @@ const std::string InfoCmd::kDataSection = "data";
 const std::string InfoCmd::kCommandStatsSection = "commandstats";
 const std::string InfoCmd::kRaftSection = "raft";
 
-const std::string InfoCmd::kInfoSection = "info";
-const std::string InfoCmd::kAllSection = "all";
-const std::string InfoCmd::kServerSection = "server";
-const std::string InfoCmd::kClientsSection = "clients";
-const std::string InfoCmd::kStatsSection = "stats";
-const std::string InfoCmd::kCPUSection = "cpu";
-const std::string InfoCmd::kReplicationSection = "replication";
-const std::string InfoCmd::kKeyspaceSection = "keyspace";
-const std::string InfoCmd::kDataSection = "data";
-const std::string InfoCmd::kRocksDBSection = "rocksdb";
-const std::string InfoCmd::kDebugSection = "debug";
-const std::string InfoCmd::kCommandStatsSection = "commandstats";
-const std::string InfoCmd::kCacheSection = "cache";
-const std::string InfoCmd::kRaftSection = "RAFT";
-
 InfoCmd::InfoCmd(const std::string& name, int16_t arity) : BaseCmd(name, arity, kCmdFlagsAdmin, kAclCategoryAdmin) {}
 
 bool InfoCmd::DoInitial(PClient* client) {

--- a/src/cmd_admin.cc
+++ b/src/cmd_admin.cc
@@ -9,6 +9,8 @@
 #include <sys/statvfs.h>
 #include <sys/time.h>
 #include <sys/utsname.h>
+#include <algorithm>
+#include <cctype>
 
 #include "cmd_admin.h"
 #include <cstddef>
@@ -158,7 +160,7 @@ const std::string InfoCmd::kStatsSection = "stats";
 const std::string InfoCmd::kCPUSection = "cpu";
 const std::string InfoCmd::kDataSection = "data";
 const std::string InfoCmd::kCommandStatsSection = "commandstats";
-const std::string InfoCmd::kRaftSection = "RAFT";
+const std::string InfoCmd::kRaftSection = "raft";
 
 const std::string InfoCmd::kInfoSection = "info";
 const std::string InfoCmd::kAllSection = "all";
@@ -184,19 +186,23 @@ bool InfoCmd::DoInitial(PClient* client) {
     return true;
   }
 
-  const auto& argv_ = client->argv_;
-  auto it = sectionMap.find(argv_[1].data());
-  if (it != sectionMap.end()) {
-    info_section_ = it->second;
-  } else {
-    client->SetRes(CmdRes::kErrOther, "the cmd is not supported");
-    return false;
-  }
+  std::string argv_ = client->argv_[1].data();
+  //统一转换成为小写后进行比较
+  std::transform(argv_.begin(), argv_.end(), argv_.begin(), [](unsigned char c) { return std::tolower(c); });
+  if (argc == 2) {
+    auto it = sectionMap.find(argv_);
+    if (it != sectionMap.end()) {
+      info_section_ = it->second;
+    } else {
+      client->SetRes(CmdRes::kErrOther, "the cmd is not supported");
+      return false;
+    }
 
-  if (argc != 2) {
+  } else {
     client->SetRes(CmdRes::kSyntaxErr);
     return false;
   }
+
   return true;
 }
 

--- a/src/cmd_admin.cc
+++ b/src/cmd_admin.cc
@@ -380,7 +380,6 @@ void InfoCmd::InfoCPU(std::string& info) {
 }
 
 void InfoCmd::InfoData(std::string& message) {
-  message += "# DATA \r\n ";
   message += DATABASES_NUM + std::string(":") + std::to_string(pikiwidb::g_config.databases) + "\r\n";
   message += ROCKSDB_NUM + std::string(":") + std::to_string(pikiwidb::g_config.db_instance_num) + "\r\n";
   message += ROCKSDB_VERSION + std::string(":") + ROCKSDB_NAMESPACE::GetRocksVersionAsString() + "\r\n";

--- a/src/cmd_admin.cc
+++ b/src/cmd_admin.cc
@@ -12,12 +12,12 @@
 #include <algorithm>
 #include <cctype>
 
-#include "cmd_admin.h"
 #include <cstddef>
 #include <cstdint>
 #include <optional>
 #include <string>
 #include <vector>
+#include "cmd_admin.h"
 #include "db.h"
 
 #include "braft/raft.h"

--- a/src/cmd_admin.cc
+++ b/src/cmd_admin.cc
@@ -154,16 +154,10 @@ void PingCmd::DoCmd(PClient* client) { client->SetRes(CmdRes::kPong, "PONG"); }
 const std::string InfoCmd::kInfoSection = "info";
 const std::string InfoCmd::kAllSection = "all";
 const std::string InfoCmd::kServerSection = "server";
-const std::string InfoCmd::kClientsSection = "clients";
 const std::string InfoCmd::kStatsSection = "stats";
 const std::string InfoCmd::kCPUSection = "cpu";
-const std::string InfoCmd::kReplicationSection = "replication";
-const std::string InfoCmd::kKeyspaceSection = "keyspace";
 const std::string InfoCmd::kDataSection = "data";
-const std::string InfoCmd::kRocksDBSection = "rocksdb";
-const std::string InfoCmd::kDebugSection = "debug";
 const std::string InfoCmd::kCommandStatsSection = "commandstats";
-const std::string InfoCmd::kCacheSection = "cache";
 const std::string InfoCmd::kRaftSection = "RAFT";
 
 const std::string InfoCmd::kInfoSection = "info";
@@ -408,14 +402,14 @@ void InfoCmd::InfoCommandStats(PClient* client, std::string& info) {
              << "\r\n";
   auto cmdstat_map = client->GetCommandStatMap();
   for (auto iter : *cmdstat_map) {
-    if (iter.second.cmd_count != 0) {
+    if (iter.second.cmd_count_ != 0) {
       tmp_stream << iter.first << ":"
-                 << "calls=" << iter.second.cmd_count
-                 << ", usec=" << MethodofTotalTimeCalculation(iter.second.cmd_time_consuming) << ", usec_per_call=";
-      if (!iter.second.cmd_time_consuming) {
+                 << "calls=" << iter.second.cmd_count_
+                 << ", usec=" << MethodofTotalTimeCalculation(iter.second.cmd_time_consuming_) << ", usec_per_call=";
+      if (!iter.second.cmd_time_consuming_) {
         tmp_stream << 0 << "\r\n";
       } else {
-        tmp_stream << MethodofCommandStatistics(iter.second.cmd_time_consuming, iter.second.cmd_count) << "\r\n";
+        tmp_stream << MethodofCommandStatistics(iter.second.cmd_time_consuming_, iter.second.cmd_count_) << "\r\n";
       }
     }
   }

--- a/src/cmd_admin.cc
+++ b/src/cmd_admin.cc
@@ -188,6 +188,9 @@ bool InfoCmd::DoInitial(PClient* client) {
   auto it = sectionMap.find(argv_[1].data());
   if (it != sectionMap.end()) {
     info_section_ = it->second;
+  } else {
+    client->SetRes(CmdRes::kErrOther, "the cmd is not supported");
+    return false;
   }
 
   if (argc != 2) {
@@ -292,7 +295,8 @@ void InfoCmd::InfoRaft(std::string& message) {
     std::vector<braft::PeerId> peers;
     auto status = PRAFT.GetListPeers(&peers);
     if (!status.ok()) {
-      tmp_stream << "-ERR " << status.error_str()<<"\r\n";
+      tmp_stream.str("-ERR ");
+      tmp_stream << status.error_str() << "\r\n";
       return;
     }
 

--- a/src/cmd_admin.cc
+++ b/src/cmd_admin.cc
@@ -187,7 +187,7 @@ bool InfoCmd::DoInitial(PClient* client) {
   }
 
   std::string argv_ = client->argv_[1].data();
-  //统一转换成为小写后进行比较
+  // convert section to lowercase
   std::transform(argv_.begin(), argv_.end(), argv_.begin(), [](unsigned char c) { return std::tolower(c); });
   if (argc == 2) {
     auto it = sectionMap.find(argv_);
@@ -197,16 +197,13 @@ bool InfoCmd::DoInitial(PClient* client) {
       client->SetRes(CmdRes::kErrOther, "the cmd is not supported");
       return false;
     }
-
   } else {
     client->SetRes(CmdRes::kSyntaxErr);
     return false;
   }
-
   return true;
 }
 
-// @todo The info raft command is only supported for the time being
 void InfoCmd::DoCmd(PClient* client) {
   std::string info;
   switch (info_section_) {

--- a/src/cmd_admin.cc
+++ b/src/cmd_admin.cc
@@ -289,31 +289,35 @@ void InfoCmd::InfoRaft(std::string& message) {
     return;
   }
 
-  message += "raft_group_id:" + PRAFT.GetGroupID() + "\r\n";
-  message += "raft_node_id:" + PRAFT.GetNodeID() + "\r\n";
-  message += "raft_peer_id:" + PRAFT.GetPeerID() + "\r\n";
+  std::stringstream tmp_stream;
+
+  tmp_stream << "raft_group_id:" << PRAFT.GetGroupID() << "\r\n";
+  tmp_stream << "raft_node_id:" << PRAFT.GetNodeID() << "\r\n";
+  tmp_stream << "raft_peer_id:" << PRAFT.GetPeerID() << "\r\n";
   if (braft::is_active_state(node_status.state)) {
-    message += "raft_state:up\r\n";
+    tmp_stream << "raft_state:up\r\n";
   } else {
-    message += "raft_state:down\r\n";
+    tmp_stream << "raft_state:down\r\n";
   }
-  message += "raft_role:" + std::string(braft::state2str(node_status.state)) + "\r\n";
-  message += "raft_leader_id:" + node_status.leader_id.to_string() + "\r\n";
-  message += "raft_current_term:" + std::to_string(node_status.term) + "\r\n";
+  tmp_stream << "raft_role:" << std::string(braft::state2str(node_status.state)) << "\r\n";
+  tmp_stream << "raft_leader_id:" << node_status.leader_id.to_string() << "\r\n";
+  tmp_stream << "raft_current_term:" << std::to_string(node_status.term) << "\r\n";
 
   if (PRAFT.IsLeader()) {
     std::vector<braft::PeerId> peers;
     auto status = PRAFT.GetListPeers(&peers);
     if (!status.ok()) {
-      message += "-ERR:" + status.error_str();
+      tmp_stream << "-ERR:" << status.error_str();
       return;
     }
 
     for (int i = 0; i < peers.size(); i++) {
-      message += "raft_node" + std::to_string(i) + ":addr=" + butil::ip2str(peers[i].addr.ip).c_str() +
-                 ",port=" + std::to_string(peers[i].addr.port) + "\r\n";
+      tmp_stream << "raft_node" << std::to_string(i) << ":addr=" << butil::ip2str(peers[i].addr.ip).c_str()
+                 << ",port=" << std::to_string(peers[i].addr.port) << "\r\n";
     }
   }
+
+  message.append(tmp_stream.str());
 }
 
 void InfoCmd::InfoServer(std::string& info) {

--- a/src/cmd_admin.h
+++ b/src/cmd_admin.h
@@ -161,7 +161,7 @@ class InfoCmd : public BaseCmd {
   void InfoRaft(std::string& info);
   void InfoData(std::string& info);
   void InfoCommandStats(PClient* client, std::string& info);
-
+  std::string FormatCommandStatLine(const CommandStatistics& stats);
   double MethodofTotalTimeCalculation(const uint64_t time_consuming);
   double MethodofCommandStatistics(const uint64_t time_consuming, const uint64_t frequency);
 };

--- a/src/cmd_admin.h
+++ b/src/cmd_admin.h
@@ -146,6 +146,15 @@ class InfoCmd : public BaseCmd {
   const static std::string kCommandStatsSection;
   const static std::string kRaftSection;
 
+  const std::unordered_map<std::string, InfoSection> sectionMap = {{kAllSection, kInfoAll},
+                                                                   {kServerSection, kInfoServer},
+                                                                   {kStatsSection, kInfoStats},
+                                                                   {kCPUSection, kInfoCPU},
+                                                                   {kDataSection, kInfoData},
+                                                                   {kRaftSection, kInfoRaft},
+                                                                   {kCommandStatsSection, kInfoCommandStats},
+                                                                   {kRaftSection, kInfoRaft}};
+
   void InfoServer(std::string& info);
   void InfoStats(std::string& info);
   void InfoCPU(std::string& info);

--- a/src/cmd_admin.h
+++ b/src/cmd_admin.h
@@ -124,8 +124,44 @@ class InfoCmd : public BaseCmd {
  private:
   void DoCmd(PClient* client) override;
 
-  void InfoRaft(PClient* client);
-  void InfoData(PClient* client);
+  enum InfoSection {
+    kInfoErr = 0x0,
+    kInfoServer,
+    kInfoStats,
+    kInfoCPU,
+    kInfoData,
+    kInfo,
+    kInfoAll,
+    kInfoCommandStats,
+    kInfoRaft
+  };
+
+  InfoSection info_section_;
+  const static std::string kInfoSection;
+  const static std::string kAllSection;
+  const static std::string kServerSection;
+  const static std::string kClientsSection;
+  const static std::string kStatsSection;
+  const static std::string kExecCountSection;
+  const static std::string kCPUSection;
+  const static std::string kReplicationSection;
+  const static std::string kKeyspaceSection;
+  const static std::string kDataSection;
+  const static std::string kRocksDBSection;
+  const static std::string kDebugSection;
+  const static std::string kCommandStatsSection;
+  const static std::string kCacheSection;
+  const static std::string kRaftSection;
+
+  void InfoServer(std::string& info);
+  void InfoStats(std::string& info);
+  void InfoCPU(std::string& info);
+  void InfoRaft(std::string& info);
+  void InfoData(std::string& info);
+  void InfoCommandStats(PClient* client, std::string& info);
+
+  double MethodofTotalTimeCalculation(const uint64_t time_consuming);
+  double MethodofCommandStatistics(const uint64_t time_consuming, const uint64_t frequency);
 };
 
 class CmdDebug : public BaseCmdGroup {

--- a/src/cmd_admin.h
+++ b/src/cmd_admin.h
@@ -152,8 +152,7 @@ class InfoCmd : public BaseCmd {
                                                                    {kCPUSection, kInfoCPU},
                                                                    {kDataSection, kInfoData},
                                                                    {kRaftSection, kInfoRaft},
-                                                                   {kCommandStatsSection, kInfoCommandStats},
-                                                                   {kRaftSection, kInfoRaft}};
+                                                                   {kCommandStatsSection, kInfoCommandStats}};
 
   void InfoServer(std::string& info);
   void InfoStats(std::string& info);

--- a/src/cmd_admin.h
+++ b/src/cmd_admin.h
@@ -140,17 +140,10 @@ class InfoCmd : public BaseCmd {
   const static std::string kInfoSection;
   const static std::string kAllSection;
   const static std::string kServerSection;
-  const static std::string kClientsSection;
   const static std::string kStatsSection;
-  const static std::string kExecCountSection;
   const static std::string kCPUSection;
-  const static std::string kReplicationSection;
-  const static std::string kKeyspaceSection;
   const static std::string kDataSection;
-  const static std::string kRocksDBSection;
-  const static std::string kDebugSection;
   const static std::string kCommandStatsSection;
-  const static std::string kCacheSection;
   const static std::string kRaftSection;
 
   void InfoServer(std::string& info);

--- a/src/cmd_table_manager.cc
+++ b/src/cmd_table_manager.cc
@@ -209,4 +209,5 @@ bool CmdTableManager::CmdExist(const std::string& cmd) const {
 }
 
 uint32_t CmdTableManager::GetCmdId() { return ++cmdId_; }
+
 }  // namespace pikiwidb

--- a/src/cmd_thread_pool_worker.cc
+++ b/src/cmd_thread_pool_worker.cc
@@ -45,12 +45,13 @@ void CmdWorkThreadPoolWorker::Work() {
       if (cmdstat_map->find(task->CmdName()) == cmdstat_map->end()) {
         cmdstat_map->emplace(task->CmdName(), statistics);
       }
-      task->Client()->GetTimeStat()->SetDequeueTs(pstd::NowMicros());
+      auto now = std::chrono::steady_clock::now();
+      task->Client()->GetTimeStat()->SetDequeueTs(now);
       task->Run(cmdPtr);
 
       // Info Commandstats used
-
-      task->Client()->GetTimeStat()->SetProcessDoneTs(pstd::NowMicros());
+      now = std::chrono::steady_clock::now();
+      task->Client()->GetTimeStat()->SetProcessDoneTs(now);
       (*cmdstat_map)[task->CmdName()].cmd_count_.fetch_add(1);
       (*cmdstat_map)[task->CmdName()].cmd_time_consuming_.fetch_add(task->Client()->GetTimeStat()->GetTotalTime());
 

--- a/src/cmd_thread_pool_worker.cc
+++ b/src/cmd_thread_pool_worker.cc
@@ -45,14 +45,14 @@ void CmdWorkThreadPoolWorker::Work() {
       if (cmdstat_map->find(task->CmdName()) == cmdstat_map->end()) {
         cmdstat_map->emplace(task->CmdName(), statistics);
       }
-      task->Client()->time_stat_->dequeue_ts_ = pstd::NowMicros();
+      task->Client()->GetTimeStat()->SetDequeueTs(pstd::NowMicros());
       task->Run(cmdPtr);
 
       // Info Commandstats used
 
-      task->Client()->time_stat_->process_done_ts_ = pstd::NowMicros();
-      (*cmdstat_map)[task->CmdName()].cmd_count.fetch_add(1);
-      (*cmdstat_map)[task->CmdName()].cmd_time_consuming.fetch_add(task->Client()->time_stat_->total_time());
+      task->Client()->GetTimeStat()->SetProcessDoneTs(pstd::NowMicros());
+      (*cmdstat_map)[task->CmdName()].cmd_count_.fetch_add(1);
+      (*cmdstat_map)[task->CmdName()].cmd_time_consuming_.fetch_add(task->Client()->GetTimeStat()->GetTotalTime());
 
       g_pikiwidb->PushWriteTask(task->Client());
     }

--- a/src/pikiwidb.cc
+++ b/src/pikiwidb.cc
@@ -13,6 +13,7 @@
 #include <sys/fcntl.h>
 #include <sys/resource.h>
 #include <sys/wait.h>
+#include <time.h>
 #include <unistd.h>
 #include <iostream>
 #include <thread>
@@ -173,6 +174,8 @@ bool PikiwiDB::Init() {
   auto timerTask = std::make_shared<net::CommonTimerTask>(1000);
   timerTask->SetCallback([]() { PREPL.Cron(); });
   event_server_->AddTimerTask(timerTask);
+
+  time(&start_time_s_);
 
   return true;
 }

--- a/src/pikiwidb.h
+++ b/src/pikiwidb.h
@@ -63,6 +63,8 @@ class PikiwiDB final {
       const std::function<void(uint64_t, std::shared_ptr<pikiwidb::PClient>&, const net::SocketAddr&)>& onConnect,
       const std::function<void(std::string)>& cb);
 
+  time_t Start_time_s() { return start_time_s_; }
+
  public:
   PString cfg_file_;
   uint16_t port_{0};
@@ -78,6 +80,8 @@ class PikiwiDB final {
 
   std::unique_ptr<net::EventServer<std::shared_ptr<pikiwidb::PClient>>> event_server_;
   uint32_t cmd_id_ = 0;
+
+  time_t start_time_s_ = 0;
 };
 
 extern std::unique_ptr<PikiwiDB> g_pikiwidb;


### PR DESCRIPTION
误删除了之前那个PR的分支，所以提了一个新的PR，原来PR comment可看 https://github.com/OpenAtomFoundation/pikiwidb/pull/326 ，都进行了回复与处理

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **新功能**
  - 添加了新的统计和时间计算功能，可以跟踪命令统计信息和执行时间。
  - 提供了更详细的信息检索方法，包括服务器信息、统计信息、CPU 信息和数据库统计信息。
  - 引入了一个新的`InfoSection`枚举，支持不同信息区域的映射和处理。

- **改进**
  - 更新了`PClient`类，增加了获取命令统计信息和时间统计的功能。
  - `PikiwiDB`类中添加了开始时间的初始化和检索方法。

- **修复**
  - 改进了`InfoCmd`类的方法以处理不同类型的命令和信息。
  - 优化了`DoCmd`方法的逻辑，提供更详细的错误处理和信息格式。

- **重构**
  - 对多个方法进行了重构，改进了性能并增强了代码的可读性和维护性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->