### PR TITLE
fix: change the default value of ADDRESS_SANITIZER to OFF

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,7 +33,7 @@ IF(CMAKE_BUILD_TYPE STREQUAL "Release")
     MESSAGE("Building in Release mode")
 ELSE()
     MESSAGE("Building in Debug mode")
-    OPTION(ADDRESS_SANITIZER "Enable AddressSanitizer (default sanitizer)" ON)
+    OPTION(ADDRESS_SANITIZER "Enable AddressSanitizer (default sanitizer)" OFF)
     OPTION(THREAD_SANITIZER "Enable ThreadSanitizer" OFF)
 
     IF(THREAD_SANITIZER)


### PR DESCRIPTION
Issues: #339 The debug version fails to compile.
Before changing the default value of ADDRESS_SANITIZER, the same problem was encountered in a non-WSL Ubuntu 22.04 virtual machine, as shown in the following picture.
![There are also a lot of '__asan_' in Ubuntu not WSL](https://github.com/OpenAtomFoundation/pikiwidb/assets/130418683/62ecc53d-914e-47f5-bec5-50dfa4956473)
After changing the default value of ADDRESS_SANITIZER to OFF, pikiwiDB build successfully.
![build success](https://github.com/OpenAtomFoundation/pikiwidb/assets/130418683/a556046b-d75d-4463-bc09-497944de61a7)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **调整**
  - 在调试模式下构建时，将 `ADDRESS_SANITIZER` 的默认设置从 `ON` 修改为 `OFF`。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->