### PR TITLE
fix: fix a bug of hmget and Zset

### DIFF
--- a/src/cmd_hash.cc
+++ b/src/cmd_hash.cc
@@ -7,6 +7,7 @@
 #include "cmd_hash.h"
 
 #include <config.h>
+#include <iostream>
 
 #include "pstd/pstd_string.h"
 #include "store.h"
@@ -93,6 +94,10 @@ HMSetCmd::HMSetCmd(const std::string& name, int16_t arity)
     : BaseCmd(name, arity, kCmdFlagsWrite, kAclCategoryWrite | kAclCategoryHash) {}
 
 bool HMSetCmd::DoInitial(PClient* client) {
+  if (client->argv_.size() % 2 != 0) {
+    client->SetRes(CmdRes::kWrongNum, kCmdNameHMSet);
+    return false;
+  }
   client->SetKey(client->argv_[1]);
   client->ClearFvs();
   // set fvs
@@ -116,6 +121,7 @@ HMGetCmd::HMGetCmd(const std::string& name, int16_t arity)
 
 bool HMGetCmd::DoInitial(PClient* client) {
   client->SetKey(client->argv_[1]);
+  client->ClearFields();
   for (size_t i = 2; i < client->argv_.size(); ++i) {
     client->Fields().push_back(client->argv_[i]);
   }

--- a/src/cmd_hash.cc
+++ b/src/cmd_hash.cc
@@ -7,7 +7,6 @@
 #include "cmd_hash.h"
 
 #include <config.h>
-#include <iostream>
 
 #include "pstd/pstd_string.h"
 #include "store.h"

--- a/src/cmd_zset.cc
+++ b/src/cmd_zset.cc
@@ -728,7 +728,7 @@ void ZScoreCmd::DoCmd(PClient* client) {
   if (s.ok() || s.IsNotFound()) {
     char buf[32];
     int64_t len = pstd::D2string(buf, sizeof(buf), score);
-    client->AppendStringLenUint64(len);
+    client->AppendStringLen(len);
     client->AppendContent(buf);
   } else {
     client->SetRes(CmdRes::kErrOther, s.ToString());

--- a/src/cmd_zset.cc
+++ b/src/cmd_zset.cc
@@ -726,7 +726,10 @@ void ZScoreCmd::DoCmd(PClient* client) {
   storage::Status s;
   s = PSTORE.GetBackend(client->GetCurrentDB())->GetStorage()->ZScore(client->Key(), client->argv_[2], &score);
   if (s.ok() || s.IsNotFound()) {
-    client->AppendString(std::to_string(score));
+    char buf[32];
+    int64_t len = pstd::D2string(buf, sizeof(buf), score);
+    client->AppendStringLenUint64(len);
+    client->AppendContent(buf);
   } else {
     client->SetRes(CmdRes::kErrOther, s.ToString());
   }


### PR DESCRIPTION
fix #266 (zscore, hmget, hmset)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **修复**
  - 修复了在处理哈希命令时，参数数量不匹配的问题。
  - 修复了在处理哈希命令时，清空字段的问题。
  
- **改进**
  - 优化了处理有序集合命令时，将分数转换为字符串的方式，提高了响应效率。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->