### PR TITLE
feat: write to rocksdb by our Batch interface (hincrby hmset hsetnx)

### DIFF
--- a/src/storage/src/redis_hashes.cc
+++ b/src/storage/src/redis_hashes.cc
@@ -361,7 +361,7 @@ Status Redis::HIncrby(const Slice& key, const Slice& field, int64_t value, int64
 
 Status Redis::HIncrbyfloat(const Slice& key, const Slice& field, const Slice& by, std::string* new_value) {
   new_value->clear();
-  auto batch = Batch::CreateBatch(this);
+  rocksdb::WriteBatch batch;
   ScopeRecordLock l(lock_mgr_, key);
 
   uint64_t version = 0;
@@ -383,12 +383,12 @@ Status Redis::HIncrbyfloat(const Slice& key, const Slice& field, const Slice& by
       version = parsed_hashes_meta_value.UpdateVersion();
       parsed_hashes_meta_value.SetCount(1);
       parsed_hashes_meta_value.SetEtime(0);
-      batch->Put(kHashesMetaCF, base_meta_key.Encode(), meta_value);
+      batch.Put(handles_[kHashesMetaCF], base_meta_key.Encode(), meta_value);
       HashesDataKey hashes_data_key(key, version, field);
 
       LongDoubleToStr(long_double_by, new_value);
       BaseDataValue inter_value(*new_value);
-      batch->Put(kHashesDataCF, hashes_data_key.Encode(), inter_value.Encode());
+      batch.Put(handles_[kHashesDataCF], hashes_data_key.Encode(), inter_value.Encode());
     } else {
       version = parsed_hashes_meta_value.Version();
       HashesDataKey hashes_data_key(key, version, field);
@@ -407,7 +407,7 @@ Status Redis::HIncrbyfloat(const Slice& key, const Slice& field, const Slice& by
           return Status::InvalidArgument("Overflow");
         }
         BaseDataValue internal_value(*new_value);
-        batch->Put(kHashesDataCF, hashes_data_key.Encode(), internal_value.Encode());
+        batch.Put(handles_[kHashesDataCF], hashes_data_key.Encode(), internal_value.Encode());
         statistic++;
       } else if (s.IsNotFound()) {
         LongDoubleToStr(long_double_by, new_value);
@@ -416,8 +416,8 @@ Status Redis::HIncrbyfloat(const Slice& key, const Slice& field, const Slice& by
         }
         parsed_hashes_meta_value.ModifyCount(1);
         BaseDataValue internal_value(*new_value);
-        batch->Put(kHashesMetaCF, base_meta_key.Encode(), meta_value);
-        batch->Put(kHashesDataCF, hashes_data_key.Encode(), internal_value.Encode());
+        batch.Put(handles_[kHashesMetaCF], base_meta_key.Encode(), meta_value);
+        batch.Put(handles_[kHashesDataCF], hashes_data_key.Encode(), internal_value.Encode());
       } else {
         return s;
       }
@@ -426,16 +426,16 @@ Status Redis::HIncrbyfloat(const Slice& key, const Slice& field, const Slice& by
     EncodeFixed32(meta_value_buf, 1);
     HashesMetaValue hashes_meta_value(Slice(meta_value_buf, sizeof(int32_t)));
     version = hashes_meta_value.UpdateVersion();
-    batch->Put(kHashesMetaCF, base_meta_key.Encode(), hashes_meta_value.Encode());
+    batch.Put(handles_[kHashesMetaCF], base_meta_key.Encode(), hashes_meta_value.Encode());
 
     HashesDataKey hashes_data_key(key, version, field);
     LongDoubleToStr(long_double_by, new_value);
     BaseDataValue internal_value(*new_value);
-    batch->Put(kHashesDataCF, hashes_data_key.Encode(), internal_value.Encode());
+    batch.Put(handles_[kHashesDataCF], hashes_data_key.Encode(), internal_value.Encode());
   } else {
     return s;
   }
-  s = batch->Commit();
+  s = db_->Write(default_write_options_, &batch);
   UpdateSpecificKeyStatistics(DataType::kHashes, key.ToString(), statistic);
   return s;
 }

--- a/tests/consistency_test.go
+++ b/tests/consistency_test.go
@@ -153,6 +153,27 @@ var _ = Describe("Consistency", Ordered, func() {
 		}
 	})
 
+	It("HSetnx Consistency Test", func() {
+		const testKey = "HashConsistencyTest"
+		const testField = "HSetnxTestField"
+		const testValue = "HSetnxTestValue"
+
+		setnx, err := leader.HSetNX(ctx, testKey, testField, testValue).Result()
+		Expect(err).NotTo(HaveOccurred())
+		Expect(setnx).To(BeTrue())
+
+		setnx, err = leader.HSetNX(ctx, testKey, testField, "NewValue").Result()
+		Expect(err).NotTo(HaveOccurred())
+		Expect(setnx).To(BeFalse())
+
+		// read check
+		readChecker(func(c *redis.Client) {
+			hget, err := c.HGet(ctx, testKey, testField).Result()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(hget).To(Equal(testValue))
+		})
+	})
+
 	It("HMSet Consistency Test", func() {
 		const testKey = "HashConsistencyTest"
 		testValue := map[string]string{
@@ -160,17 +181,17 @@ var _ = Describe("Consistency", Ordered, func() {
 			"fb": "vb",
 			"fc": "vc",
 		}
-    // write on leader
-    hmset, err := leader.HMSet(ctx, testKey, testValue).Result()
-    Expect(err).NotTo(HaveOccurred())
-    Expect(hmset).To(BeTrue())
+		// write on leader
+		hmset, err := leader.HMSet(ctx, testKey, testValue).Result()
+		Expect(err).NotTo(HaveOccurred())
+		Expect(hmset).To(BeTrue())
 
-    // read check
-    readChecker(func(c *redis.Client) {
-      getall, err := c.HGetAll(ctx, testKey).Result()
-      Expect(err).NotTo(HaveOccurred())
-      Expect(getall).To(Equal(testValue))
-    })
+		// read check
+		readChecker(func(c *redis.Client) {
+			getall, err := c.HGetAll(ctx, testKey).Result()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(getall).To(Equal(testValue))
+		})
 	})
 
 	It("HIncrby Consistency Test", func() {

--- a/tests/consistency_test.go
+++ b/tests/consistency_test.go
@@ -11,7 +11,6 @@ import (
 	"bufio"
 	"context"
 	"log"
-	"math"
 	"os/exec"
 	"strconv"
 	"strings"
@@ -234,53 +233,6 @@ var _ = Describe("Consistency", Ordered, func() {
 			hget, err := c.HGet(ctx, testKey, testField).Result()
 			Expect(err).NotTo(HaveOccurred())
 			Expect(hget).To(Equal("-5"))
-		})
-	})
-
-	It("HIncrbyfloat Consistency Test", func() {
-		const testKey = "HashConsistencyTest"
-		const testField = "HIncrbyField"
-		// write on leader
-		set, err := leader.HSet(ctx, testKey, testField, 10.5).Result()
-		Expect(err).NotTo(HaveOccurred())
-		Expect(set).To(Equal(int64(1)))
-
-		// incrby 0.1
-		hincrbyfloat, err := leader.HIncrByFloat(ctx, testKey, testField, 0.1).Result()
-		Expect(err).NotTo(HaveOccurred())
-		Expect(hincrbyfloat).To(Equal(10.6))
-		// read check
-		readChecker(func(c *redis.Client) {
-			hget, err := c.HGet(ctx, testKey, testField).Result()
-			Expect(err).NotTo(HaveOccurred())
-			hgetfloat, err := strconv.ParseFloat(hget, 64)
-			Expect(err).NotTo(HaveOccurred())
-			Expect(math.Abs(hgetfloat-10.6) < 0.0000001).To(BeTrue())
-		})
-
-		// incrby -5
-		hincrbyfloat, err = leader.HIncrByFloat(ctx, testKey, testField, -5).Result()
-		Expect(err).NotTo(HaveOccurred())
-		Expect(hincrbyfloat).To(Equal(5.6))
-		// read check
-		readChecker(func(c *redis.Client) {
-			hget, err := c.HGet(ctx, testKey, testField).Result()
-			Expect(err).NotTo(HaveOccurred())
-			Expect(hget).To(Equal("5.6"))
-		})
-
-		set, err = leader.HSet(ctx, testKey, testField, 5.0e3).Result()
-		Expect(err).NotTo(HaveOccurred())
-		Expect(set).To(Equal(int64(0)))
-		// incrby 2e2
-		hincrbyfloat, err = leader.HIncrByFloat(ctx, testKey, testField, 2.0e2).Result()
-		Expect(err).NotTo(HaveOccurred())
-		Expect(hincrbyfloat).To(Equal(5200.0))
-		// read check
-		readChecker(func(c *redis.Client) {
-			hget, err := c.HGet(ctx, testKey, testField).Result()
-			Expect(err).NotTo(HaveOccurred())
-			Expect(hget).To(Equal("5200"))
 		})
 	})
 

--- a/tests/consistency_test.go
+++ b/tests/consistency_test.go
@@ -153,6 +153,26 @@ var _ = Describe("Consistency", Ordered, func() {
 		}
 	})
 
+	It("HMSet Consistency Test", func() {
+		const testKey = "HashConsistencyTest"
+		testValue := map[string]string{
+			"fa": "va",
+			"fb": "vb",
+			"fc": "vc",
+		}
+    // write on leader
+    hmset, err := leader.HMSet(ctx, testKey, testValue).Result()
+    Expect(err).NotTo(HaveOccurred())
+    Expect(hmset).To(BeTrue())
+
+    // read check
+    readChecker(func(c *redis.Client) {
+      getall, err := c.HGetAll(ctx, testKey).Result()
+      Expect(err).NotTo(HaveOccurred())
+      Expect(getall).To(Equal(testValue))
+    })
+	})
+
 	It("HIncrby Consistency Test", func() {
 		const testKey = "HashConsistencyTest"
 		const testField = "HIncrbyField"

--- a/tests/consistency_test.go
+++ b/tests/consistency_test.go
@@ -11,6 +11,7 @@ import (
 	"bufio"
 	"context"
 	"log"
+	"math"
 	"os/exec"
 	"strconv"
 	"strings"
@@ -252,7 +253,9 @@ var _ = Describe("Consistency", Ordered, func() {
 		readChecker(func(c *redis.Client) {
 			hget, err := c.HGet(ctx, testKey, testField).Result()
 			Expect(err).NotTo(HaveOccurred())
-			Expect(hget).To(Equal("10.6"))
+			hgetfloat, err := strconv.ParseFloat(hget, 64)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(math.Abs(hgetfloat-10.6) < 0.0000001).To(BeTrue())
 		})
 
 		// incrby -5

--- a/tests/consistency_test.go
+++ b/tests/consistency_test.go
@@ -904,7 +904,7 @@ var _ = Describe("Consistency", Ordered, func() {
 func readChecker(check func(*redis.Client)) {
 	// read on leader
 	check(leader)
-	time.Sleep(10000 * time.Millisecond)
+	time.Sleep(1000 * time.Millisecond)
 
 	// read on followers
 	followerChecker(followers, check)


### PR DESCRIPTION
issure: https://github.com/OpenAtomFoundation/pikiwidb/issues/280

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **测试**
  - 添加了一系列一致性测试，用于验证Redis命令（如`HSetnx`、`HMSet`、`HIncrby`、`HIncrbyfloat`、`SAdd`和`SRem`）的操作一致性和正确性。
- **重构**
  - 改进了Redis类中的批处理操作，提升了写操作的抽象层次，可能提高了性能和可靠性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->