### PR TITLE
feat: enable wal in single mode

### DIFF
--- a/src/db.cc
+++ b/src/db.cc
@@ -121,6 +121,11 @@ void DB::LoadDBFromCheckpoint(const std::string& checkpoint_path, bool sync [[ma
     abort();
   }
 
+  // in single-mode, pikiwidb will enable wal
+  if (!g_config.use_raft.load(std::memory_order_relaxed)) {
+    storage_->DisableWal(false);
+  }
+
   opened_ = true;
   INFO("DB{} load a checkpoint from {} success!", db_index_, checkpoint_path);
 }

--- a/src/pikiwidb.cc
+++ b/src/pikiwidb.cc
@@ -172,8 +172,6 @@ bool PikiwiDB::Init() {
     PREPL.SetMasterAddr(g_config.master_ip.ToString().c_str(), g_config.master_port.load());
   }
 
-  //  cmd_table_manager_.InitCmdTable();
-
   return true;
 }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **修复错误**
  - 基于配置标志在从检查点加载数据库时禁用预写日志（WAL）。
  - 删除了 `PikiwiDB::Init()` 函数中的 `cmd_table_manager_.InitCmdTable();` 行。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->