### PR TITLE
feat: add client cmd

### DIFF
--- a/.github/workflows/pikiwidb.yml
+++ b/.github/workflows/pikiwidb.yml
@@ -67,4 +67,4 @@ jobs:
         run: |
           cd ../tests
           go mod tidy
-          go test
+          go test -timeout 15

--- a/src/base_cmd.h
+++ b/src/base_cmd.h
@@ -75,6 +75,13 @@ const std::string kCmdNameUnwatch = "unwatch";
 const std::string kCmdNameDiscard = "discard";
 
 // admin
+const std::string kCmdNameClient = "client";
+const std::string kSubCmdNameClientGetname = "getname";
+const std::string kSubCmdNameClientSetname = "setname";
+const std::string kSubCmdNameClientId = "id";
+const std::string kSubCmdNameClientList = "list";
+const std::string kSubCmdNameClientKill = "kill";
+
 const std::string kCmdNameConfig = "config";
 const std::string kSubCmdNameConfigGet = "get";
 const std::string kSubCmdNameConfigSet = "set";

--- a/src/client.cc
+++ b/src/client.cc
@@ -21,6 +21,9 @@
 
 namespace pikiwidb {
 
+
+const ClientInfo ClientInfo::invalidClientInfo = {-1, "", -1, -1};
+
 void CmdRes::RedisAppendLen(std::string& str, int64_t ori, const std::string& prefix) {
   str.append(prefix);
   str.append(pstd::Int2string(ori));
@@ -144,6 +147,7 @@ void CmdRes::SetRes(CmdRes::CmdRet _ret, const std::string& content) {
 CmdRes::~CmdRes() { message_.clear(); }
 
 thread_local PClient* PClient::s_current = nullptr;
+
 
 std::mutex monitors_mutex;
 std::set<std::weak_ptr<PClient>, std::owner_less<std::weak_ptr<PClient> > > monitors;
@@ -482,6 +486,13 @@ int PClient::PeerPort() const {
   return -1;
 }
 
+const int PClient::GetFd() const {
+  if (auto c = getTcpConnection(); c) {
+    return c->Fd();
+  }
+  return -1;
+}
+
 bool PClient::SendPacket(const std::string& buf) {
   if (auto c = getTcpConnection(); c) {
     return c->SendPacket(buf);
@@ -544,12 +555,19 @@ bool PClient::isClusterCmdTarget() const {
   return PRAFT.GetClusterCmdCtx().GetPeerIp() == PeerIP() && PRAFT.GetClusterCmdCtx().GetPort() == PeerPort();
 }
 
-int PClient::uniqueID() const {
+int PClient::GetUniqueId() const {
   if (auto c = getTcpConnection(); c) {
     return c->GetUniqueId();
   }
 
   return -1;
+}
+
+ClientInfo PClient::GetClientInfo() const { 
+  if(auto c = getTcpConnection(); c) {
+    return {GetUniqueId(), PeerIP().c_str(), PeerPort(), GetFd()};
+  }
+  return ClientInfo::invalidClientInfo;
 }
 
 bool PClient::Watch(int dbno, const std::string& key) {
@@ -559,12 +577,12 @@ bool PClient::Watch(int dbno, const std::string& key) {
 
 bool PClient::NotifyDirty(int dbno, const std::string& key) {
   if (IsFlagOn(kClientFlagDirty)) {
-    INFO("client is already dirty {}", uniqueID());
+    INFO("client is already dirty {}", GetUniqueId());
     return true;
   }
 
   if (watch_keys_[dbno].contains(key)) {
-    INFO("{} client become dirty because key {} in db {}", uniqueID(), key, dbno);
+    INFO("{} client become dirty because key {} in db {}", GetUniqueId(), key, dbno);
     SetFlag(kClientFlagDirty);
     return true;
   } else {

--- a/src/client.h
+++ b/src/client.h
@@ -19,7 +19,6 @@
 #include "storage/storage.h"
 
 namespace pikiwidb {
-
 class CmdRes {
  public:
   enum CmdRet {
@@ -110,6 +109,14 @@ enum class ClientState {
 class DB;
 struct PSlaveInfo;
 
+struct ClientInfo{
+  int client_id;
+  std::string ip;
+  int port;
+  int fd;
+  static const ClientInfo invalidClientInfo;
+  bool operator==(ClientInfo& ci) const{return client_id == ci.client_id;}
+}; 
 class PClient : public std::enable_shared_from_this<PClient>, public CmdRes {
  public:
   PClient() = delete;
@@ -121,6 +128,9 @@ class PClient : public std::enable_shared_from_this<PClient>, public CmdRes {
 
   const std::string& PeerIP() const;
   int PeerPort() const;
+  const int GetFd() const;
+  int GetUniqueId() const;
+  ClientInfo GetClientInfo() const;
 
   bool SendPacket(const std::string& buf);
   bool SendPacket(const void* data, size_t size);
@@ -216,13 +226,12 @@ class PClient : public std::enable_shared_from_this<PClient>, public CmdRes {
   std::span<std::string> argv_;
 
  private:
-  std::shared_ptr<TcpConnection> getTcpConnection() const { return tcp_connection_.lock(); }
+std::shared_ptr<TcpConnection> getTcpConnection() const { return tcp_connection_.lock(); }
   int handlePacket(const char*, int);
   void executeCommand();
   int processInlineCmd(const char*, size_t, std::vector<std::string>&);
   void reset();
   bool isPeerMaster() const;
-  int uniqueID() const;
 
   bool isClusterCmdTarget() const;
 
@@ -263,6 +272,7 @@ class PClient : public std::enable_shared_from_this<PClient>, public CmdRes {
   time_t last_auth_ = 0;
 
   ClientState state_;
+
 
   static thread_local PClient* s_current;
 };

--- a/src/cmd_admin.cc
+++ b/src/cmd_admin.cc
@@ -258,4 +258,39 @@ void CmdDebugSegfault::DoCmd(PClient* client) {
   *ptr = 0;
 }
 
+CmdClient::ClientCmd(const std::string & name, int arity):BaseCmdGroup(name,  kCmdFlagsReadOnly|kCmdFlagsAdmin, kAclCategoryAdmin){}
+
+bool CmdClient::HasSubCommand() const {return true; }
+
+CmdClientGetname::CmdClientGetname(const std::string& name, int16_t arity) 
+  : BaseCmd(name, arity, kCmdFlagsAdmin | kCmdFlagsReadOnly, kAclCategoryAdmin) {}
+
+bool CmdClientGetname::DoInitial(PClient* client) {return true; }
+
+void CmdClientGetname::DoCmd(PClient* client) {
+  std::string result = client->GetName();
+  client->AppendString(result);
+}
+
+CmdClientSetname::CmdClientSetname(const std::string& name, int16_t arity) 
+  : BaseCmd(name, arity, kCmdFlagsAdmin | kCmdFlagsWrite, kAclCategoryAdmin) {}
+
+
+bool CmdClientSetname::DoInitial(PClient* client) {return true; }
+
+void pikiwidb::CmdClientSetname::DoCmd(PClient* client) {
+  std::string result = client->SetName(client->argv_[3]);
+}
+
+CmdClientKill::CmdClientKill(const std::string& name, int16_t arity)
+  : BaseCmd(name, arity, kCmdFlagsAdmin, kAclCategoryAdmin) {
+}
+
+bool CmdClientKill::DoInitial(PClient* client) { return true; }
+
+void CmdClientKill::DoCmd(PClient* client) {}
+  // PSTORE.GetBackend(client->GetCurrentDB())->UnLockShared();
+  // g_pikiwidb->Stop();
+  // PSTORE.GetBackend(client->GetCurrentDB())->LockShared();
+  client->SetRes(CmdRes::kNone);
 }  // namespace pikiwidb

--- a/src/cmd_admin.cc
+++ b/src/cmd_admin.cc
@@ -258,19 +258,21 @@ void CmdDebugSegfault::DoCmd(PClient* client) {
   *ptr = 0;
 }
 
-CmdClient::ClientCmd(const std::string & name, int arity):BaseCmdGroup(name,  kCmdFlagsReadOnly|kCmdFlagsAdmin, kAclCategoryAdmin){}
+
+CmdClient::CmdClient(const std::string & name, int arity):BaseCmdGroup(name,  kCmdFlagsReadonly|kCmdFlagsAdmin, kAclCategoryAdmin){}
 
 bool CmdClient::HasSubCommand() const {return true; }
 
+
 CmdClientGetname::CmdClientGetname(const std::string& name, int16_t arity) 
-  : BaseCmd(name, arity, kCmdFlagsAdmin | kCmdFlagsReadOnly, kAclCategoryAdmin) {}
+  : BaseCmd(name, arity, kCmdFlagsAdmin | kCmdFlagsReadonly, kAclCategoryAdmin) {}
 
 bool CmdClientGetname::DoInitial(PClient* client) {return true; }
 
 void CmdClientGetname::DoCmd(PClient* client) {
-  std::string result = client->GetName();
-  client->AppendString(result);
+  client->AppendString(client->GetName());
 }
+
 
 CmdClientSetname::CmdClientSetname(const std::string& name, int16_t arity) 
   : BaseCmd(name, arity, kCmdFlagsAdmin | kCmdFlagsWrite, kAclCategoryAdmin) {}
@@ -279,18 +281,139 @@ CmdClientSetname::CmdClientSetname(const std::string& name, int16_t arity)
 bool CmdClientSetname::DoInitial(PClient* client) {return true; }
 
 void pikiwidb::CmdClientSetname::DoCmd(PClient* client) {
-  std::string result = client->SetName(client->argv_[3]);
+  client->SetName(client->argv_[3]);
+  client->SetRes(CmdRes::kOK);
 }
+
+CmdClientId::CmdClientId(const std::string& name, int16_t arity)
+  : BaseCmd(name, arity, kCmdFlagsAdmin | kCmdFlagsReadonly, kAclCategoryAdmin) {}
+
+bool CmdClientId::DoInitial(PClient* client) { return true; }
+
+void CmdClientId::DoCmd(PClient* client) {
+  client->AppendInteger(client->GetUniqueId());
+}
+
 
 CmdClientKill::CmdClientKill(const std::string& name, int16_t arity)
   : BaseCmd(name, arity, kCmdFlagsAdmin, kAclCategoryAdmin) {
 }
 
-bool CmdClientKill::DoInitial(PClient* client) { return true; }
+bool CmdClientKill::DoInitial(PClient* client) { 
+  if(strcasecmp(client->argv_[2].data(), "all")== 0){
+    kill_type_ = Type::ALL;
+    return true;
+  }else if(client->argv_[2].size() == 3 && strcasecmp(client->argv_[2].data(), "addr")== 0){
+    kill_type_ = Type::ADDR;
+    return true;
+  }else if(client->argv_[2].size() == 3 && strcasecmp(client->argv_[2].data(), "id")== 0){
+    kill_type_ = Type::ID;
+    return true;
+  }else{
+    client->SetRes(CmdRes::kWrongNum, client->CmdName());
+    return false;
+  }
+}
 
-void CmdClientKill::DoCmd(PClient* client) {}
-  // PSTORE.GetBackend(client->GetCurrentDB())->UnLockShared();
-  // g_pikiwidb->Stop();
-  // PSTORE.GetBackend(client->GetCurrentDB())->LockShared();
-  client->SetRes(CmdRes::kNone);
+void CmdClientKill::DoCmd(PClient* client) {
+  bool ret;
+  switch(kill_type_){
+    case Type::ALL:
+    {
+      ret = g_pikiwidb->KillAllClients();
+      break;
+    }
+    case Type::ADDR:
+    {
+      ret = g_pikiwidb->KillClientsByAddrPort(client->argv_[3]);
+      break;
+    }
+    case Type::ID:
+    {
+      ret = g_pikiwidb->KillClientsByAddrPort(client->argv_[3]);
+    }
+    default:
+      break;
+  }
+  if(ret){
+
+  }
+
+  ret == true ? client->SetRes(CmdRes::kOK) : client->SetRes(CmdRes::kErrOther, "no such client");
+}
+
+CmdClientList::CmdClientList(const std::string& name, int16_t arity)
+  : BaseCmd(name, arity, kCmdFlagsAdmin, kAclCategoryAdmin) {}
+
+bool CmdClientList::DoInitial(PClient * client){
+  if(client->argv_.size() == 2){
+    list_type_ = Type::DEFAULT; 
+    return true;
+  }
+  if(client->argv_.size() > 3 && strcasecmp(client->argv_[2].data(), "id")== 0){
+    list_type_ = Type:: ID;
+    return true;
+  }
+  // if (client->argv_.size() == 5 && (strcasecmp(client->argv_[2].data(), "order") == 0) && (strcasecmp(client->argv_[3].data(), "by") == 0)) {
+  //   if(strcasecmp(client->argv_[4].data(), "addr")==0){
+  //     list_type_ = ListType::ADDR;
+  //     info_ = client->argv_[4];
+  //     return true;
+  //   }else if(strcasecmp(client->argv_[4].data(), "idle")==0){
+  //     list_type_ = ListType::IDLE;
+  //     info_ = client->argv_[4];
+  //     return true;
+  //   } else {
+  //     client->SetRes(CmdRes::kErrOther, "Syntax error, try CLIENT (LIST [order by [addr|idle])");
+  //     return false;
+  //   }
+  // } else {
+  //     client->SetRes(CmdRes::kErrOther, "Syntax error, try CLIENT (LIST [order by [addr|idle])");
+  //     return false;
+  // }
+  return true; 
+}
+
+void CmdClientList::DoCmd(PClient* client) {
+  switch (list_type_)
+  {
+  case Type::DEFAULT:
+  {
+    std::vector<pikiwidb::ClientInfo> client_infos;
+    g_pikiwidb->GetAllClientInfos(client_infos);
+    for(auto &client_info : client_infos){
+      // client->
+      char buf[128];
+      snprintf(buf, sizeof(buf), "ID=%d IP=%s PORT=%d FD=%d\n", 
+              client_info.client_id, client_info.ip.c_str(), client_info.port, client_info.fd);
+      client->AppendString(std::string(buf));
+    }
+    break;
+  }
+  case Type::ID:
+  {
+
+    for(size_t i = 3; i < client->argv_.size(); i++){
+      try
+      {
+        int client_id = std::stoi(client->argv_[i]);
+        auto client_info = g_pikiwidb->GetClientsInfoById(client_id);
+        char buf[128];
+        snprintf(buf, sizeof(buf), "ID=%d IP=%s PORT=%d FD=%d\n", 
+                client_info.client_id, client_info.ip.c_str(), client_info.port, client_info.fd);
+        client->AppendString(std::string(buf));
+        break;
+      }
+      catch(const std::exception& e)
+      {
+        client->SetRes(CmdRes::kErrOther, "Invalid client id");
+        std::cerr << e.what() << '\n';
+      }
+    }
+  }
+  default:
+    break;
+  }
+
+}
 }  // namespace pikiwidb

--- a/src/cmd_admin.cc
+++ b/src/cmd_admin.cc
@@ -281,7 +281,7 @@ CmdClientSetname::CmdClientSetname(const std::string& name, int16_t arity)
 bool CmdClientSetname::DoInitial(PClient* client) {return true; }
 
 void pikiwidb::CmdClientSetname::DoCmd(PClient* client) {
-  client->SetName(client->argv_[3]);
+  client->SetName(client->argv_[2]);
   client->SetRes(CmdRes::kOK);
 }
 
@@ -343,7 +343,7 @@ void CmdClientKill::DoCmd(PClient* client) {
 }
 
 CmdClientList::CmdClientList(const std::string& name, int16_t arity)
-  : BaseCmd(name, arity, kCmdFlagsAdmin, kAclCategoryAdmin) {}
+  : BaseCmd(name, arity, kCmdFlagsAdmin|kCmdFlagsReadonly, kAclCategoryAdmin) {}
 
 bool CmdClientList::DoInitial(PClient * client){
   if(client->argv_.size() == 2){
@@ -371,7 +371,8 @@ bool CmdClientList::DoInitial(PClient * client){
   //     client->SetRes(CmdRes::kErrOther, "Syntax error, try CLIENT (LIST [order by [addr|idle])");
   //     return false;
   // }
-  return true; 
+  client->SetRes(CmdRes::kErrOther, "Syntax error, try CLIENT (LIST [ID client_id_1, client_id_2...])");
+  return false; 
 }
 
 void CmdClientList::DoCmd(PClient* client) {

--- a/src/cmd_admin.cc
+++ b/src/cmd_admin.cc
@@ -17,6 +17,7 @@
 
 #include "store.h"
 
+
 namespace pikiwidb {
 
 CmdConfig::CmdConfig(const std::string& name, int arity) : BaseCmdGroup(name, kCmdFlagsAdmin, kAclCategoryAdmin) {}
@@ -303,10 +304,10 @@ bool CmdClientKill::DoInitial(PClient* client) {
   if(strcasecmp(client->argv_[2].data(), "all")== 0){
     kill_type_ = Type::ALL;
     return true;
-  }else if(client->argv_[2].size() == 3 && strcasecmp(client->argv_[2].data(), "addr")== 0){
+  }else if(client->argv_.size() == 4 && strcasecmp(client->argv_[2].data(), "addr")== 0){
     kill_type_ = Type::ADDR;
     return true;
-  }else if(client->argv_[2].size() == 3 && strcasecmp(client->argv_[2].data(), "id")== 0){
+  }else if(client->argv_.size() == 4 && strcasecmp(client->argv_[2].data(), "id")== 0){
     kill_type_ = Type::ID;
     return true;
   }else{
@@ -325,21 +326,23 @@ void CmdClientKill::DoCmd(PClient* client) {
     }
     case Type::ADDR:
     {
-      ret = g_pikiwidb->KillClientsByAddrPort(client->argv_[3]);
+      ret = g_pikiwidb->KillClientByAddrPort(client->argv_[3]);
       break;
     }
     case Type::ID:
     {
-      ret = g_pikiwidb->KillClientsByAddrPort(client->argv_[3]);
+      try {
+        int client_id = stoi(client->argv_[3]);
+        ret = g_pikiwidb->KillClientById(client_id);
+      } catch (const std::exception& e) {
+        client->SetRes(CmdRes::kErrOther, "Invalid client id");
+        return;
+      }
     }
     default:
       break;
   }
-  if(ret){
-
-  }
-
-  ret == true ? client->SetRes(CmdRes::kOK) : client->SetRes(CmdRes::kErrOther, "no such client");
+  ret == true ? client->SetRes(CmdRes::kOK) : client->SetRes(CmdRes::kErrOther, "No such client");
 }
 
 CmdClientList::CmdClientList(const std::string& name, int16_t arity)
@@ -354,23 +357,6 @@ bool CmdClientList::DoInitial(PClient * client){
     list_type_ = Type:: ID;
     return true;
   }
-  // if (client->argv_.size() == 5 && (strcasecmp(client->argv_[2].data(), "order") == 0) && (strcasecmp(client->argv_[3].data(), "by") == 0)) {
-  //   if(strcasecmp(client->argv_[4].data(), "addr")==0){
-  //     list_type_ = ListType::ADDR;
-  //     info_ = client->argv_[4];
-  //     return true;
-  //   }else if(strcasecmp(client->argv_[4].data(), "idle")==0){
-  //     list_type_ = ListType::IDLE;
-  //     info_ = client->argv_[4];
-  //     return true;
-  //   } else {
-  //     client->SetRes(CmdRes::kErrOther, "Syntax error, try CLIENT (LIST [order by [addr|idle])");
-  //     return false;
-  //   }
-  // } else {
-  //     client->SetRes(CmdRes::kErrOther, "Syntax error, try CLIENT (LIST [order by [addr|idle])");
-  //     return false;
-  // }
   client->SetRes(CmdRes::kErrOther, "Syntax error, try CLIENT (LIST [ID client_id_1, client_id_2...])");
   return false; 
 }
@@ -382,9 +368,13 @@ void CmdClientList::DoCmd(PClient* client) {
   {
     std::vector<pikiwidb::ClientInfo> client_infos;
     g_pikiwidb->GetAllClientInfos(client_infos);
+    client->AppendArrayLen(client_infos.size());
+    if(client_infos.size() == 0){
+      return;
+    }
+    char buf[128];
     for(auto &client_info : client_infos){
       // client->
-      char buf[128];
       snprintf(buf, sizeof(buf), "ID=%d IP=%s PORT=%d FD=%d\n", 
               client_info.client_id, client_info.ip.c_str(), client_info.port, client_info.fd);
       client->AppendString(std::string(buf));
@@ -393,6 +383,7 @@ void CmdClientList::DoCmd(PClient* client) {
   }
   case Type::ID:
   {
+    client->AppendArrayLen(client->argv_.size() - 3);
 
     for(size_t i = 3; i < client->argv_.size(); i++){
       try
@@ -403,14 +394,14 @@ void CmdClientList::DoCmd(PClient* client) {
         snprintf(buf, sizeof(buf), "ID=%d IP=%s PORT=%d FD=%d\n", 
                 client_info.client_id, client_info.ip.c_str(), client_info.port, client_info.fd);
         client->AppendString(std::string(buf));
-        break;
       }
       catch(const std::exception& e)
       {
         client->SetRes(CmdRes::kErrOther, "Invalid client id");
-        std::cerr << e.what() << '\n';
+        return;
       }
     }
+    break;
   }
   default:
     break;

--- a/src/cmd_admin.h
+++ b/src/cmd_admin.h
@@ -79,6 +79,79 @@ class FlushallCmd : public BaseCmd {
   void DoCmd(PClient* client) override;
 };
 
+class CmdClient : public BaseCmdGroup {
+ public:
+  ClientCmd(const std::string& name, int arity);
+  bool HasSubCommand() const override;
+
+ protected:
+  std::string operation_, info_;
+  void DoInitial(PClient* client) override{return true;}
+
+private:
+  const static std::string CLIENT_LIST_S;
+  const static std::string CLIENT_KILL_S;
+
+  void DoCmd(PClient* client) override{}
+};
+
+class CmdClientGetname: public BaseCmd{
+ public:
+  CmdClientGetname(const std::string& name, int16_t arity);
+
+ protected:
+  bool DoInitial(PClient* client) override;
+
+ private:
+  void DoCmd(PClient* client) override;
+};
+
+class CmdClientSetname: public BaseCmd{
+ public:
+  CmdClientSetname(const std::string& name, int16_t arity);
+
+ protected:
+  bool DoInitial(PClient* client) override;
+
+ private:
+  void DoCmd(PClient* client) override;
+};
+
+
+class CmdClientSetname: public BaseCmd{
+ public:
+  CmdClientSetname(const std::string& name, int16_t arity);
+
+ protected:
+  bool DoInitial(PClient* client) override;
+
+ private:
+  void DoCmd(PClient* client) override;
+};
+
+class CmdClientList: public BaseCmd{
+ public:
+  CmdClientList(const std::string& name, int16_t arity);
+
+ protected:
+  bool DoInitial(PClient* client) override;
+
+ private:
+  void DoCmd(PClient* client) override;
+};
+
+
+class CmdClientKill: public BaseCmd{
+ public:
+  CmdClientKill(const std::string& name, int16_t arity);
+
+ protected:
+  bool DoInitial(PClient* client) override;
+
+ private:
+  void DoCmd(PClient* client) override;
+};
+
 class SelectCmd : public BaseCmd {
  public:
   SelectCmd(const std::string& name, int16_t arity);

--- a/src/cmd_admin.h
+++ b/src/cmd_admin.h
@@ -81,12 +81,12 @@ class FlushallCmd : public BaseCmd {
 
 class CmdClient : public BaseCmdGroup {
  public:
-  ClientCmd(const std::string& name, int arity);
+  CmdClient(const std::string& name, int arity);
   bool HasSubCommand() const override;
 
  protected:
   std::string operation_, info_;
-  void DoInitial(PClient* client) override{return true;}
+  bool DoInitial(PClient* client) override{return true;}
 
 private:
   const static std::string CLIENT_LIST_S;
@@ -117,10 +117,9 @@ class CmdClientSetname: public BaseCmd{
   void DoCmd(PClient* client) override;
 };
 
-
-class CmdClientSetname: public BaseCmd{
+class CmdClientId: public BaseCmd{
  public:
-  CmdClientSetname(const std::string& name, int16_t arity);
+  CmdClientId(const std::string& name, int16_t arity);
 
  protected:
   bool DoInitial(PClient* client) override;
@@ -129,7 +128,15 @@ class CmdClientSetname: public BaseCmd{
   void DoCmd(PClient* client) override;
 };
 
+
+
+
 class CmdClientList: public BaseCmd{
+ private:
+  enum class Type{
+    DEFAULT, IDLE,  ADDR, ID 
+  } list_type_;
+  std::string info_;
  public:
   CmdClientList(const std::string& name, int16_t arity);
 
@@ -142,6 +149,10 @@ class CmdClientList: public BaseCmd{
 
 
 class CmdClientKill: public BaseCmd{
+ private:
+  enum class Type{
+    ALL, ADDR, ID 
+  } kill_type_;
  public:
   CmdClientKill(const std::string& name, int16_t arity);
 
@@ -151,6 +162,8 @@ class CmdClientKill: public BaseCmd{
  private:
   void DoCmd(PClient* client) override;
 };
+
+
 
 class SelectCmd : public BaseCmd {
  public:

--- a/src/cmd_table_manager.cc
+++ b/src/cmd_table_manager.cc
@@ -58,6 +58,12 @@ void CmdTableManager::InitCmdTable() {
   ADD_SUBCOMMAND(Debug, OOM, 2);
   ADD_SUBCOMMAND(Debug, Segfault, 2);
 
+  ADD_COMMAND_GROUP(Client, -2);
+  ADD_SUBCOMMAND(Client, Getname, 2);
+  ADD_SUBCOMMAND(Client, Setname, 3);
+  ADD_SUBCOMMAND(Client, List, -2);
+  ADD_SUBCOMMAND(Client, Kill, 3);
+
   // server
   ADD_COMMAND(Flushdb, 1);
   ADD_COMMAND(Flushall, 1);

--- a/src/cmd_table_manager.cc
+++ b/src/cmd_table_manager.cc
@@ -61,8 +61,9 @@ void CmdTableManager::InitCmdTable() {
   ADD_COMMAND_GROUP(Client, -2);
   ADD_SUBCOMMAND(Client, Getname, 2);
   ADD_SUBCOMMAND(Client, Setname, 3);
+  ADD_SUBCOMMAND(Client, Id, 2);
   ADD_SUBCOMMAND(Client, List, -2);
-  ADD_SUBCOMMAND(Client, Kill, 3);
+  ADD_SUBCOMMAND(Client, Kill, -3);
 
   // server
   ADD_COMMAND(Flushdb, 1);

--- a/src/net/tcp_listener.cc
+++ b/src/net/tcp_listener.cc
@@ -92,11 +92,11 @@ void TcpListener::OnNewConnection(struct evconnlistener*, evutil_socket_t fd, st
     auto on_create = acceptor->on_new_conn_;  // cpp11 doesn't support lambda capture initializers
     auto create_conn = [loop, on_create, fd, ipstr, port]() {
       auto conn(std::make_shared<TcpConnection>(loop));
-      conn->SetNewConnCallback(on_create);
-      conn->OnAccept(fd, ipstr, port);
       if (!loop->Register(conn, 0)) {
         ERROR("Failed to register socket {}", fd);
       }
+      conn->SetNewConnCallback(on_create);
+      conn->OnAccept(fd, ipstr, port);
     };
     loop->Execute(std::move(create_conn));
   } else {

--- a/src/pikiwidb.cc
+++ b/src/pikiwidb.cc
@@ -111,8 +111,6 @@ void PikiwiDB::OnNewConnection(pikiwidb::TcpConnection* obj) {
 
   client->OnConnect();
 
-  //add new PClient to clients 
-  clients[client->GetUniqueId()] = client.get();
 
   auto msg_cb = std::bind(&pikiwidb::PClient::HandlePackets, client.get(), std::placeholders::_1, std::placeholders::_2,
                           std::placeholders::_3);
@@ -125,6 +123,10 @@ void PikiwiDB::OnNewConnection(pikiwidb::TcpConnection* obj) {
   obj->SetNodelay(true);
   obj->SetEventLoopSelector([this]() { return worker_threads_.ChooseNextWorkerEventLoop(); });
   obj->SetSlaveEventLoopSelector([this]() { return slave_threads_.ChooseNextWorkerEventLoop(); });
+
+  //add new PClient to clients 
+  clients[client->GetUniqueId()] = client.get();
+  INFO("new client id{}", obj->GetUniqueId());
 }
 
 uint32_t PikiwiDB::GetAllClientInfos(std::vector<ClientInfo>& results)

--- a/src/pikiwidb.cc
+++ b/src/pikiwidb.cc
@@ -126,7 +126,6 @@ void PikiwiDB::OnNewConnection(pikiwidb::TcpConnection* obj) {
 
   //add new PClient to clients 
   clients[client->GetUniqueId()] = client.get();
-  INFO("new client id{}", obj->GetUniqueId());
 }
 
 uint32_t PikiwiDB::GetAllClientInfos(std::vector<ClientInfo>& results)
@@ -169,7 +168,7 @@ bool PikiwiDB::KillAllClients() {
 
 
 
-bool PikiwiDB::KillClientsByAddrPort(const std::string& addr_port) {
+bool PikiwiDB::KillClientByAddrPort(const std::string& addr_port) {
   std::shared_lock<std::shared_mutex> client_map_lock(client_map_mutex);
   for(auto& [id, client] : clients){
     std::string client_ip_port = client->PeerIP() + ":" + std::to_string(client->PeerPort());

--- a/src/pikiwidb.cc
+++ b/src/pikiwidb.cc
@@ -111,16 +111,83 @@ void PikiwiDB::OnNewConnection(pikiwidb::TcpConnection* obj) {
 
   client->OnConnect();
 
+  //add new PClient to clients 
+  clients[client->GetUniqueId()] = client.get();
+
   auto msg_cb = std::bind(&pikiwidb::PClient::HandlePackets, client.get(), std::placeholders::_1, std::placeholders::_2,
                           std::placeholders::_3);
   obj->SetMessageCallback(msg_cb);
   obj->SetOnDisconnect([](pikiwidb::TcpConnection* obj) {
     INFO("disconnect from {}", obj->GetPeerIP());
     obj->GetContext<pikiwidb::PClient>()->SetState(pikiwidb::ClientState::kClosed);
+    g_pikiwidb->RemoveClientMetaById(obj->GetUniqueId());
   });
   obj->SetNodelay(true);
   obj->SetEventLoopSelector([this]() { return worker_threads_.ChooseNextWorkerEventLoop(); });
   obj->SetSlaveEventLoopSelector([this]() { return slave_threads_.ChooseNextWorkerEventLoop(); });
+}
+
+uint32_t PikiwiDB::GetAllClientInfos(std::vector<ClientInfo>& results)
+{
+  std::shared_lock<std::shared_mutex> client_map_lock(client_map_mutex);
+  //client info string type: ip, port, fd.
+  for(auto& [id, client] : clients){
+    if(auto clientInfo = client->GetClientInfo(); clientInfo != ClientInfo::invalidClientInfo){
+      results.emplace_back(clientInfo);
+    }
+  }
+  return results.size();
+}
+ClientInfo PikiwiDB::GetClientsInfoById(int id){
+  std::shared_lock client_map_lock(client_map_mutex);
+  if(auto it = clients.find(id); it != clients.end()){
+    return it->second->GetClientInfo();
+  }
+    return ClientInfo::invalidClientInfo; 
+}
+
+bool PikiwiDB::RemoveClientMetaById(int id) { 
+  std::unique_lock client_map_lock(client_map_mutex);
+  if(auto it = clients.find(id); it != clients.end()){
+    clients.erase(it);
+    return true;
+  }
+  return false; 
+}
+
+bool PikiwiDB::KillAllClients() {
+  std::shared_lock<std::shared_mutex> client_map_lock(client_map_mutex);
+  for(auto& [id, client] : clients){
+    client_map_lock.unlock();
+    client->Close();
+    client_map_lock.lock();
+  }
+  return true;
+}
+
+
+
+bool PikiwiDB::KillClientsByAddrPort(const std::string& addr_port) {
+  std::shared_lock<std::shared_mutex> client_map_lock(client_map_mutex);
+  for(auto& [id, client] : clients){
+    std::string client_ip_port = client->PeerIP() + ":" + std::to_string(client->PeerPort());
+    if(client_ip_port == addr_port){
+      client_map_lock.unlock();
+      client->Close();
+      return true;
+    }
+  }
+  return false;
+}
+
+bool PikiwiDB::KillClientById(int client_id) {
+  std::shared_lock<std::shared_mutex> client_map_lock(client_map_mutex);
+  if(auto it = clients.find(client_id); it != clients.end()){
+    client_map_lock.unlock();
+    it->second->Close();
+    return true;
+  }
+  return false;
 }
 
 bool PikiwiDB::Init() {

--- a/src/pikiwidb.h
+++ b/src/pikiwidb.h
@@ -10,7 +10,6 @@
 #include "common.h"
 #include "io_thread_pool.h"
 #include "net/tcp_connection.h"
-#include <optional>
 
 #define KPIKIWIDB_VERSION "4.0.0"
 

--- a/src/pikiwidb.h
+++ b/src/pikiwidb.h
@@ -54,7 +54,7 @@ class PikiwiDB final {
   bool RemoveClientMetaById(int id);
 
   bool KillAllClients();
-  bool KillClientsByAddrPort(const std::string& addr_port);
+  bool KillClientByAddrPort(const std::string& addr_port);
   bool KillClientById(int client_id);
 
  public:

--- a/src/pikiwidb.h
+++ b/src/pikiwidb.h
@@ -10,6 +10,7 @@
 #include "common.h"
 #include "io_thread_pool.h"
 #include "net/tcp_connection.h"
+#include <optional>
 
 #define KPIKIWIDB_VERSION "4.0.0"
 
@@ -45,6 +46,17 @@ class PikiwiDB final {
 
   void PushWriteTask(const std::shared_ptr<pikiwidb::PClient>& client) { worker_threads_.PushWriteTask(client); }
 
+
+  //client message function
+  uint32_t GetAllClientInfos(std::vector<pikiwidb::ClientInfo>& results);
+  pikiwidb::ClientInfo GetClientsInfoById(int id);
+
+  bool RemoveClientMetaById(int id);
+
+  bool KillAllClients();
+  bool KillClientsByAddrPort(const std::string& addr_port);
+  bool KillClientById(int client_id);
+
  public:
   PString cfg_file_;
   uint16_t port_{0};
@@ -60,8 +72,12 @@ class PikiwiDB final {
   pikiwidb::IOThreadPool slave_threads_;
   pikiwidb::CmdThreadPool cmd_threads_;
   //  pikiwidb::CmdTableManager cmd_table_manager_;
-
+  //use std::list to store client pointer as a double linked list
+  std::shared_mutex client_map_mutex;
+  std::mutex killer_mutex;
+  std::map<int, pikiwidb::PClient*> clients;
   uint32_t cmd_id_ = 0;
+  std::atomic<int64_t> client_id_ = 0;
 };
 
 extern std::unique_ptr<PikiwiDB> g_pikiwidb;

--- a/tests/admin_test.go
+++ b/tests/admin_test.go
@@ -159,4 +159,23 @@ var _ = Describe("Admin", Ordered, func() {
 		// Expect(res.Err()).NotTo(HaveOccurred())
 		// Expect(res.Val()).To(Equal(map[string]string{"timeout": "0"}))
 	})
+
+	It("Cmd Client", func() {
+		get := client.ClientGetName(ctx)
+		Expect(get.Err()).NotTo(HaveOccurred())
+		Expect(get.Val()).To(Equal("clientxxx"))
+
+		resId := client.ClientID(ctx).Err()
+		Expect(resId).NotTo(HaveOccurred())
+		Expect(client.ClientID(ctx).Val()).To(BeNumerically(">=", 0))
+
+		resKillFilter := client.ClientKillByFilter(ctx, "ADDR", "1.1.1.1:1111")
+		Expect(resKillFilter.Err()).To(MatchError("ERR No such client"))
+		Expect(resKillFilter.Val()).To(Equal(int64(0)))
+
+		resKillFilter = client.ClientKillByFilter(ctx, "ID", "1")
+		Expect(resKillFilter.Err()).To(MatchError("ERR No such client"))
+		Expect(resKillFilter.Val()).To(Equal(int64(0)))
+	})
+
 })

--- a/tests/assets/default.conf
+++ b/tests/assets/default.conf
@@ -10,7 +10,7 @@ port 9221
 # If you want you can bind a single interface, if the bind option is not
 # specified all the interfaces will listen for incoming connections.
 #
-# bind 127.0.0.1
+ip 127.0.0.1
 
 
 # Close the connection after a client is idle for N seconds (0 to disable)
@@ -35,7 +35,7 @@ logfile stdout
 # Set the number of databases. The default database is DB 0, you can select
 # a different one on a per-connection basis using SELECT <dbid> where
 # dbid is a number between 0 and 'databases'-1
-databases 3
+databases 16
 
 ################################ SNAPSHOTTING  #################################
 #
@@ -261,7 +261,6 @@ maxmemory-policy noeviction
 #
 maxmemory-samples 5
 
-
 ################################ THREADED I/O #################################
 # So for instance if you have a four cores boxes, try to use 2 or 3 I/O
 # threads, if you have a 8 cores, try to use 6 threads. In order to
@@ -315,37 +314,35 @@ slowlog-log-slower-than 10000
 # You can reclaim memory used by the slow log with SLOWLOG RESET.
 slowlog-max-len 128
 
-############################### ADVANCED CONFIG ###############################
-
-# Redis calls an internal function to perform many background tasks, like
-# closing connections of clients in timeot, purging expired keys that are
-# never requested, and so forth.
-#
-# Not all tasks are perforemd with the same frequency, but Redis checks for
-# tasks to perform accordingly to the specified "hz" value.
-#
-# By default "hz" is set to 10. Raising the value will use more CPU when
-# Redis is idle, but at the same time will make Redis more responsive when
-# there are many keys expiring at the same time, and timeouts may be
-# handled with more precision.
-#
-# The range is between 1 and 500, however a value over 100 is usually not
-# a good idea. Most users should use the default of 10 and raise this up to
-# 100 only in environments where very low latency is required.
-hz 10
 ############################### BACKENDS CONFIG ###############################
-# PikiwiDB is a in memory database, though it has aof and rdb for dump data to disk, it
-# is very limited. Try use leveldb for real storage, pikiwidb as cache. The cache algorithm
-# is like linux page cache, please google or read your favorite linux book
-# 0 is default, no backend
-# 1 is RocksDB, currently only support RocksDB
-backend 1
-backendpath dump
-# the frequency of dump to backend per second
-backendhz 10
-# the rocksdb number per db
-db-instance-num 5
+# PikiwiDB uses RocksDB as the underlying storage engine, and the data belonging
+# to the same DB is distributed among several RocksDB instances.
+
+# RocksDB instances number per DB
+db-instance-num 3
+# default is 86400 * 7
+small-compaction-threshold 604800
+# default is 86400 * 3
+small-compaction-duration-threshold 259200
+
+############################### ROCKSDB CONFIG ###############################
+rocksdb-max-subcompactions 2
+rocksdb-max-background-jobs 4
+rocksdb-max-write-buffer-number 2
+rocksdb-min-write-buffer-number-to-merge 2
+# default is 64M
+rocksdb-write-buffer-size 67108864
+rocksdb-level0-file-num-compaction-trigger 4
+rocksdb-number-levels 7
+rocksdb-enable-pipelined-write no
+rocksdb-level0-slowdown-writes-trigger 20
+rocksdb-level0-stop-writes-trigger 36
 # default 86400 * 7
 rocksdb-ttl-second 604800
 # default 86400 * 3
-rocksdb-periodic-second 259200
+rocksdb-periodic-second 259200;
+
+############################### RAFT ###############################
+use-raft no
+# Braft relies on brpc to communicate via the default port number plus the port offset
+raft-port-offset 10


### PR DESCRIPTION
add client command and corresponding got test 
CLIENT <GETNAME | SETNAME name | LIST [ID client_id1...client_idn] | KILL all | KILL ID client_id | KILL ADDR ip:port>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新功能**
  - 添加了客户端管理功能，包括获取所有客户端信息、按ID获取客户端信息、按ID移除客户端元数据、杀死所有客户端、按地址端口杀死客户端以及按ID杀死客户端。
  - 引入了新的数据结构，如 `client_map_mutex`、`killer_mutex`、`clients`、`cmd_id_` 和 `client_id_`。

- **配置更新**
  - 增加了多个 RocksDB 配置设置。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->