### PR TITLE
feat: add monitor cmd

### DIFF
--- a/src/client.cc
+++ b/src/client.cc
@@ -617,9 +617,9 @@ void PClient::TransferToSlaveThreads() {
   //  }
 }
 
-void PClient::AddCurrentToMonitor() {
+void PClient::AddToMonitor() {
   std::unique_lock<std::mutex> guard(monitors_mutex);
-  monitors.insert(std::static_pointer_cast<PClient>(s_current->shared_from_this()));
+  monitors.insert(weak_from_this());
 }
 
 void PClient::FeedMonitors(const std::vector<std::string>& params) {

--- a/src/client.h
+++ b/src/client.h
@@ -209,8 +209,8 @@ class PClient : public std::enable_shared_from_this<PClient>, public CmdRes {
   void SetSlaveInfo();
   PSlaveInfo* GetSlaveInfo() const { return slave_info_.get(); }
   void TransferToSlaveThreads();
+  void AddToMonitor();
 
-  static void AddCurrentToMonitor();
   static void FeedMonitors(const std::vector<std::string>& params);
 
   void SetAuth() { auth_ = true; }

--- a/src/cmd_admin.cc
+++ b/src/cmd_admin.cc
@@ -465,4 +465,14 @@ void SortCmd::InitialArgument() {
   get_patterns_.clear();
   ret_.clear();
 }
+MonitorCmd::MonitorCmd(const std::string& name, int arity)
+    : BaseCmd(name, arity, kCmdFlagsReadonly | kCmdFlagsAdmin, kAclCategoryAdmin) {}
+
+bool MonitorCmd::DoInitial(PClient* client) { return true; }
+
+void MonitorCmd::DoCmd(PClient* client) {
+  client->AddToMonitor();
+  client->SetRes(CmdRes::kOK);
+}
+
 }  // namespace pikiwidb

--- a/src/cmd_admin.h
+++ b/src/cmd_admin.h
@@ -21,6 +21,7 @@ const std::vector<std::string> debugHelps = {"DEBUG <subcommand> [<arg> [value] 
                                              "    Crash the server simulating an out-of-memory error."};
 
 namespace pikiwidb {
+const std::string kCmdNameMonitor = "monitor";
 
 class CmdConfig : public BaseCmdGroup {
  public:
@@ -168,6 +169,17 @@ class CmdDebugSegfault : public BaseCmd {
   CmdDebugSegfault(const std::string& name, int16_t arity);
 
  protected:
+  bool DoInitial(PClient* client) override;
+
+ private:
+  void DoCmd(PClient* client) override;
+};
+
+class MonitorCmd : public BaseCmd {
+ public:
+  MonitorCmd(const std::string& name, int arity);
+
+protected:
   bool DoInitial(PClient* client) override;
 
  private:

--- a/src/cmd_admin.h
+++ b/src/cmd_admin.h
@@ -179,7 +179,7 @@ class MonitorCmd : public BaseCmd {
  public:
   MonitorCmd(const std::string& name, int arity);
 
-protected:
+ protected:
   bool DoInitial(PClient* client) override;
 
  private:

--- a/src/cmd_table_manager.cc
+++ b/src/cmd_table_manager.cc
@@ -58,6 +58,7 @@ void CmdTableManager::InitCmdTable() {
   ADD_SUBCOMMAND(Debug, OOM, 2);
   ADD_SUBCOMMAND(Debug, Segfault, 2);
   ADD_COMMAND(Sort, -2);
+  ADD_COMMAND(Monitor, 1);
 
   // server
   ADD_COMMAND(Flushdb, 1);

--- a/tests/admin_test.go
+++ b/tests/admin_test.go
@@ -255,7 +255,7 @@ var _ = Describe("Admin", Ordered, func() {
 
 	It("should monitor", Label("monitor"), func() {
 		ress := make(chan string)
-		client1 := redis.NewClient(&redis.Options{Addr: "127.0.0.1"})
+		client1 := s.NewClient()
 		mn := client1.Monitor(ctx, ress)
 		mn.Start()
 		// Wait for the Redis server to be in monitoring mode.
@@ -271,8 +271,15 @@ var _ = Describe("Admin", Ordered, func() {
 		}
 		mn.Stop()
 		Expect(lst[0]).To(ContainSubstring("OK"))
-		Expect(lst[1]).To(ContainSubstring(`"set" "foo" "bar"`))
-		Expect(lst[2]).To(ContainSubstring(`"set" "bar" "baz"`))
-		Expect(lst[3]).To(ContainSubstring(`"set" "bap" "8"`))
+		Expect(lst[2]).To(ContainSubstring(`"set foo bar"`))
+		Expect(lst[3]).To(ContainSubstring(`"set bar baz"`))
+		Expect(lst[4]).To(ContainSubstring(`"set bap 8"`))
+
+		err := client1.Close()
+		if err != nil {
+			log.Println("Close monitor client conn fail.", err.Error())
+			return
+		}
+
 	})
 })


### PR DESCRIPTION
the main change: 
* change staic PClient::AddCurrentToMonitor to mem function AddToMonitor
* add monitor commnad

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **新功能**
  - 引入了`MonitorCmd`类，提供了构造函数和处理监控客户端活动的命令方法。
  - 在命令表中添加了`Monitor`命令，增强了监控功能。
- **重构**
  - 将`PClient`类中的方法`AddCurrentToMonitor`重命名为`AddToMonitor`，并使用`weak_from_this()`进行更新。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->