### PR TITLE
fix: kqueue evnet del write event does not exist

### DIFF
--- a/src/net/kqueue_event.cc
+++ b/src/net/kqueue_event.cc
@@ -50,14 +50,21 @@ void KqueueEvent::AddEvent(uint64_t id, int fd, int mask) {
 }
 
 void KqueueEvent::DelEvent(int fd) {
-  struct kevent change;
-  EV_SET(&change, fd, EVENT_READ, EV_DELETE, 0, 0, nullptr);
-  if (kevent(EvFd(), &change, 1, nullptr, 0, nullptr) == -1) {
-    ERROR("KqueueEvent Del read Event EvFd:{}，fd:{}, kevent error:{}", EvFd(), fd, errno);
+  if (mode_ & EVENT_MODE_READ) {
+    struct kevent change;
+    EV_SET(&change, fd, EVENT_READ, EV_DELETE, 0, 0, nullptr);
+    if (kevent(EvFd(), &change, 1, nullptr, 0, nullptr) == -1) {
+      ERROR("KqueueEvent Del read Event EvFd:{}，fd:{}, kevent error:{}", EvFd(), fd, errno);
+    }
   }
-  EV_SET(&change, fd, EVENT_WRITE, EV_DELETE, 0, 0, nullptr);
-  if (kevent(EvFd(), &change, 1, nullptr, 0, nullptr) == -1) {
-    ERROR("KqueueEvent Del write Event EvFd:{}，fd:{}, kevent error:{}", EvFd(), fd, errno);
+  if (mode_ & EVENT_MODE_WRITE) {
+    struct kevent change;
+    EV_SET(&change, fd, EVENT_WRITE, EV_DELETE, 0, 0, nullptr);
+    if (kevent(EvFd(), &change, 1, nullptr, 0, nullptr) == -1) {
+      if (errno != ENOENT) {  // If the event does not exist, it will return ENOENT
+        ERROR("KqueueEvent Del write Event EvFd:{}，fd:{}, kevent error:{}", EvFd(), fd, errno);
+      }
+    }
   }
 }
 
@@ -191,18 +198,26 @@ void KqueueEvent::DoWrite(const struct kevent &event, const std::shared_ptr<Conn
     return;
   }
   if (ret == 0) {
-    DelWriteEvent(reinterpret_cast<uint64_t>(event.udata), conn->fd_);
-#  ifdef HAVE_32BIT
+#  ifdef HAVE_64BIT
+    auto connId = reinterpret_cast<uint64_t>(event.udata);
+#  else
+    auto _connId = reinterpret_cast<uint64_t *>(event.udata);
+    uint64_t connId = *_connId;
     delete event.udata;
 #  endif
+    DelWriteEvent(connId, conn->fd_);
   }
 }
 
 void KqueueEvent::DoError(const struct kevent &event, std::string &&err) {
-  onClose_(reinterpret_cast<uint64_t>(event.udata), std::move(err));
-#  ifdef HAVE_32BIT
+#  ifdef HAVE_64BIT
+  auto connId = reinterpret_cast<uint64_t>(event.udata);
+#  else
+  auto _connId = reinterpret_cast<uint64_t *>(event.udata);
+  uint64_t connId = *_connId;
   delete event.udata;
 #  endif
+  onClose_(connId, std::move(err));
 }
 
 }  // namespace net

--- a/src/net/kqueue_event.h
+++ b/src/net/kqueue_event.h
@@ -51,7 +51,7 @@ class KqueueEvent : public BaseEvent {
   void DoError(const struct kevent &event, std::string &&err);
 
  private:
-  const int eventsSize = 1020;
+  const int eventsSize = 1024;
 };
 
 }  // namespace net


### PR DESCRIPTION
修复kqueue 中,删除不存在的事件, 错误的写入error log

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新特性**
  - 优化了事件删除和连接管理功能，提升事件管理的效率和可靠性。

- **bug修复**
  - 改进了写事件删除的错误处理，避免了不必要的日志记录。

- **性能提升**
  - 增加了事件数组的大小，支持更多事件的处理。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->