### PR TITLE
fix: pttl cmd error

### DIFF
--- a/src/cmd_keys.cc
+++ b/src/cmd_keys.cc
@@ -231,7 +231,7 @@ void PttlCmd::DoCmd(PClient* client) {
   if (timestamp == -3) {
     client->SetRes(CmdRes::kErrOther, "ttl internal error");
   } else {
-    client->AppendInteger(timestamp);
+    client->AppendInteger(timestamp * 1000);
   }
 }
 


### PR DESCRIPTION
关联issue: https://github.com/OpenAtomFoundation/pikiwidb/issues/431
![image](https://github.com/user-attachments/assets/ad5411db-6ab9-4e7d-940e-e7981f3625d7)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **新功能**
	- 修改了时间戳的处理方式，现在以毫秒格式表示，提供更高的精度。
- **错误修复**
	- 确保任何时间戳为 -3 的情况仍会返回错误响应，增强了异常处理。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->